### PR TITLE
[PAR-129] TLM1126 - Additional info observability

### DIFF
--- a/swagger-apis/metrics-collection-platform/2.1.2.yml
+++ b/swagger-apis/metrics-collection-platform/2.1.2.yml
@@ -1,0 +1,3695 @@
+openapi: 3.0.3
+info:
+  title: "Plataforma de Coleta de Métricas"
+  description: |
+    # Introdução
+
+    A Plataforma de Coleta de Métricas foi idealizada para contabilizar as interações entre as instituições participantes, de modo a promover um ambiente equitativo e não discriminatório. Se trata de uma Plataforma localizada no perímetro central, gerida pelo regulador do ecossistema.
+
+    ## Motivação
+
+    Para que o ecossistema do Open Finance Brasil seja saudável para instituições e clientes finais, fez-se necessária a criação de uma Plataforma que deverá concentrar dados sobre as chamadas que as instituições fazem umas às outras. Dessa forma, permite-se coletar informações visando criar métricas e indicadores a fim de se ter visibilidade sobre todo o ambiente.
+
+    No intuito de manter a integridade e consistência nos dados, o envio destes pelas instituições deverá passar por um processo de conciliação. Quando divergente, as instituições serão notificadas e terão a possibilidade de ajustar os reportes, o que promove um ambiente saudável de autorregulação, prevenindo assim uma disputa.
+
+    ## O que a Plataforma não é
+
+    A Plataforma recebe os dados de maneira póstuma, ou seja, dentro do período de fechamento, mas após a chamada concreta ter sido feita. Dada essa natureza, a Plataforma não pode atuar como um agente que proíbe, bloqueia ou interfere nas interações entre as instituições.
+
+    Por mais que concentre informações importantes das chamadas entre as instituições, a Plataforma não é uma ferramenta de BI, e o controle de acesso aos dados é feito em diferentes níveis (participante, regulador e administrador).
+
+    ## Premissas Técnicas
+
+    * Tanto o envio por parte dos participantes quanto o processamento por parte da Plataforma serão feitos de maneira assíncrona;
+
+    ## Terminologia
+
+    * **Server e Client**: em uma interação, a parte que solicita os dados é chamada de _client_, ao passo que a parte que devolve os dados é o _server_. O ponto de vista para o uso dessa terminologia é o tráfego dos dados da transação e não o ponto de partida da chamada. Portanto, supondo que A faça uma consulta em B pelos dados de uma conta, esses dados vão ser transmitidos por quem recebeu a solicitação, e recebidos por quem a fez, nesse caso, "A" é o Client e "B" é o Server.
+
+    * **Reporte**: no contexto da API de Coleta de Métricas, um _reporte_ é o registro da chamada que será enviado tanto pelo server quanto pelo client. Esse registro será armazenado na Plataforma para posterior processo de conciliação de chamadas e extração de dados estatísticos.
+
+    * **Divergência**: Quando Server e Client enviam reportes, cada um destes reportes se refere a uma chamada em específico. Nos casos em que uma das partes não envia o reporte sobre essa chamada em específico, é caracterizada uma divergência. As divergências podem ser resolvidas pela chamada às operações de modificação de reportes em suas respectivas APIs. Uma divergência é considerada fechada apenas quando todos os reportes encontram sua respectiva correspondência do outro lado da chamada.
+
+
+    Para informações detalhadas sobre a PCM, consulte o [site da documentação da Plataforma](https://openfinancebrasil.atlassian.net/wiki/spaces/OF/pages/17378055/Plataforma+de+Coleta+de+M+tricas).
+
+  version: 2.1.1
+  contact:
+    name: Governança Open Finance Brasil
+  license:
+    name: Licença Proprietária (uso interno restrito)
+
+security:
+  - PCMAccessToken: []
+
+servers:
+  - url: https://api.pcm.sandbox.openfinancebrasil.org.br
+    description: UAT
+  - url: https://api.pcm.openfinancebrasil.org.br
+    description: Produção
+
+tags:
+  - name: Private API
+    description: |
+      A Private API fornece operações que permitem a inclusão dos reportes que representam transações entre participantes do ecossistema do Open Finance.
+  - name: Opendata API
+    description: |
+      A Opendata API fornece operações que permitem a inclusão dos reportes cujas chamadas foram feitas nas API de dados abertos do Open Finance o qual não sofrem processo de conciliação.
+  - name: Hybrid Flow API
+    description: |
+      Oferece operações que permitem a inclusão de reportes relativos à jornada de autorização de consentimento. Os reportes podem ser feitos até às 08h00 de D+1 da data da ocorrência e não precisam ser enviados em ordem.
+
+      [Ver diagrama de sequência](https://github.com/OpenBanking-Brasil/specs-pcm/blob/feature/PCM-122/openapi/hybrid-flow-diagram.svg?raw=true)
+      
+      [Ver fluxograma de envio de reports](https://raw.githubusercontent.com/OpenBanking-Brasil/specs-pcm/feature/PCM-122/openapi/Diagrama%20API%20PCM%20Hybrid%20Flow_v3.drawio.svg)
+  - name: "Consents API"
+    description: |
+      API dedicada para obtenção de estoque de consentimento, à partir do auto reporte das instituições, com endpoint único para os papeis Client/Server.
+
+paths:
+  "/report-api/v1/private/report":
+    post:
+      tags:
+        - Private API
+      summary: Inclusão de reportes
+      description: |
+        Inclusão de reportes na plataforma. Ao enviar um lote de reportes, a plataforma vai fazer o processo de validação de cada reporte de maneira síncrona e devolver o resultado dessa validação na resposta. O status HTTP de retorno será 200 caso **todos** dos reportes enviados forem aceitos. Caso pelo menos 1 reporte esteja inconsistente, o status de retorno será 207 - veja documentação de cada status de retorno para mais informações. 
+
+        Os dados inseridos na API de Reporte são sempre processados de maneira assíncrona, e sua persistência se utiliza de consistência posterior (eventual consistency), portanto, um registro tem um tempo de processamento em que ele não estará disponível para consulta até que ele seja persistido.
+
+        O limite de reportes de cada envio de lote é de 5.000 entradas no array.
+      operationId: add-reports
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              maxItems: 5000
+              items:
+                oneOf:
+                  - $ref: "#/components/schemas/ClientReportRequest"
+                  - $ref: "#/components/schemas/ServerReportRequest"
+
+            examples:
+              "Request Valido":
+                description: O request apresentado tem todos os campos validados.
+                value:
+                  - timestamp: "2021-11-11T18:08:08.894Z"
+                    fapiInteractionId: "d78fc4e5-37ca-4da3-adf2-9b082bf92280"
+                    clientSSId: "f0b5419b-2b5f-4f59-9862-6d2a8e23be26"
+                    clientOrgId: "082ff90b-9d65-46bb-b123-b88eb47fd61c"
+                    serverOrgId: "b8e34d5a-2ed5-451e-8ddb-45a1edc76243"
+                    endpoint: "/open-banking/products-services/v1/business-financings"
+                    statusCode: 200
+                    httpMethod: GET
+                    correlationId: "wNupARo7I9E2PLJZph18a0M9y7DcUe7ITt3DqUOJd9NVjnskxf"
+                    processTimespan: 120
+                    endpointUriPrefix: "https://ofin.bank.com/"
+                    role: CLIENT
+                    additionalInfo:
+                      personType: "PF"
+                      consentId: "uri:bank:d1541b17-3175-477d-a52b-2813ae2c4c36"
+                  - timestamp: "2021-11-11T19:22:10.334Z"
+                    fapiInteractionId: "0786fce3-a36f-43f8-b66a-d26ab1dfc639"
+                    clientSSId: "f0b5419b-2b5f-4f59-9862-6d2a8e23be26"
+                    clientOrgId: "082ff90b-9d65-46bb-b123-b88eb47fd61c"
+                    serverOrgId: "b8e34d5a-2ed5-451e-8ddb-45a1edc76243"
+                    endpoint: "/open-banking/products-services/v1/business-financings"
+                    statusCode: 200
+                    httpMethod: GET
+                    correlationId: "8qPzRL4nBzesCc3H1827UlqqEuTT4F5lN82DuJllcnL5VnnY5j"
+                    processTimespan: 117
+                    endpointUriPrefix: "https://ofin.bank.com/"
+                    role: CLIENT
+                    additionalInfo:
+                      personType: "PF"
+                      consentId: "uri:bank:d1541b17-3175-477d-a52b-2813ae2c4c36"
+                  - timestamp: "2021-11-11T19:41:41.811Z"
+                    fapiInteractionId: "d1541b17-3175-477d-a52b-2813ae2c4c36"
+                    clientOrgId: "082ff90b-9d65-46bb-b123-b88eb47fd61c"
+                    serverOrgId: "b8e34d5a-2ed5-451e-8ddb-45a1edc76243"
+                    endpoint: "/open-banking/products-services/v1/business-financings"
+                    statusCode: 200
+                    httpMethod: GET
+                    processTimespan: 125
+                    role: SERVER
+        required: true
+      responses:
+        "200":
+          description: |
+            O status 200 representa a situação onde todos os registros enviados no lote foram validados e serão direcionados para processamento. Se pelo menos 1 registro contiver problemas de validação, o retorno será 207 (veja descrição do status).
+
+            A operação vai devolver um array com todos os resultados, e garante que ele esteja na mesma ordem do array da requisição.
+          content:
+            application/json:
+              schema:
+                type: array
+                maxItems: 5000
+                items:
+                  $ref: "#/components/schemas/ReportResponse"
+              examples:
+                Todos Processados:
+                  description: Esta seria a resposta para uma solicitação com o exemplo "Request Válido" da documentação. O payload da resposta vem na mesma ordem do array da solicitação. Uma vez que todos os registros foram validados, o status de retorno é o 200.
+                  value:
+                    - reportId: 424ad55c-36cc-4077-b85e-c22ea984cc4a
+                      correlationId: wNupARo7I9E2PLJZph18a0M9y7DcUe7ITt3DqUOJd9NVjnskxf
+                      status: ACCEPTED
+                    - reportId: 4095388d-f44f-499a-a9a7-2dbffce1bb8a
+                      correlationId: 8qPzRL4nBzesCc3H1827UlqqEuTT4F5lN82DuJllcnL5VnnY5j
+                      status: ACCEPTED
+                    - reportId: 0f3fcceb-39f6-41b4-a75d-8444244bd836
+                      status: ACCEPTED
+
+        "207":
+          description: |
+            O status 207 (Multi-Status) informa ao solicitante que o formato da requisição está correto, mas que entradas do array contém erro de validação em pelo menos 1 item. Ou seja, se todos os elementos do array informado estiverem com falha de validação, a operação vai devolver o status 207, e no corpo da resposta todos os elementos do array vão estar com status `DISCARDED` e com sua respectiva mensagem. 
+
+            A operação vai devolver um array com todos os resultados, e garante que ele esteja na mesma ordem do array da requisição.
+          content:
+            application/json:
+              schema:
+                type: array
+                maxItems: 5000
+                items:
+                  $ref: "#/components/schemas/ReportResponse"
+              examples:
+                "Primeiro registro com falha":
+                  description: |
+                    No caso apresentado é o resultado onde o exemplo "Request com falha" foi enviado: o registro com o _fapiInteractionId_ `d78fc4e5-37ca-4da3-adf2-9b082bf92280` apresentou uma falha na validação, mas os demais foram enviados para processamento. Como um dos registros não foi validado, o status de retorno passa a ser 207, e os demais registros são processados normalmente.
+                  value:
+                    - reportId: 424ad55c-36cc-4077-b85e-c22ea984cc4a
+                      correlationId: wNupARo7I9E2PLJZph18a0M9y7DcUe7ITt3DqUOJd9NVjnskxf
+                      status: DISCARDED
+                      message: "Missing fields: 'fapiInteractionId'"
+                    - reportId: 4095388d-f44f-499a-a9a7-2dbffce1bb8a
+                      correlationId: 8qPzRL4nBzesCc3H1827UlqqEuTT4F5lN82DuJllcnL5VnnY5j
+                      status: ACCEPTED
+                    - reportId: 0f3fcceb-39f6-41b4-a75d-8444244bd836
+                      status: ACCEPTED
+                "Todos registros com falha":
+                  description: |
+                    Neste caso, parte-se da premissa que todos os registros foram enviados sem _correlationId_ e sem _uri_. Nesse caso, todos vão falhar na etapa de validação, mas mesmo quando todos os registros falham, o status de retorno é o 207.
+                  value:
+                    - reportId: 424ad55c-36cc-4077-b85e-c22ea984cc4a
+                      status: DISCARDED
+                      message: "Missing fields: 'fapiInteractionId'"
+                    - reportId: 4095388d-f44f-499a-a9a7-2dbffce1bb8a
+                      status: DISCARDED
+                      message: "Missing fields: 'fapiInteractionId'"
+                    - reportId: 0f3fcceb-39f6-41b4-a75d-8444244bd836
+                      status: DISCARDED
+                      message: "Missing fields: 'fapiInteractionId'"
+                "Campo obrigatório não enviado":
+                  description: |
+                    Registro com campo obrigatório não enviado.
+                  value:
+                    - reportId: 424ad55c-36cc-4077-b85e-c22ea984cc4a,
+                      correlationId: wNupARo7I9E2PLJZph18a0M9y7DcUe7ITt3DqUOJd9NVjnskxf,
+                      status: DISCARDED,
+                      message: "Missing fields: 'statusCode'"
+
+        "400":
+          description: O formato do corpo da requisição não é um array.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GenericError"
+              examples:
+                "400":
+                  value:
+                    message: "Invalid payload format: MUST be an array"
+
+        "413":
+          description: A quantidade de registros enviado excede o limite da operação (5.000 elementos no array), ou o tamanho do payload excede 10Mb.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GenericError"
+              examples:
+                "Limite de registros excedido":
+                  value:
+                    message: Record limit exceeded
+
+        "401":
+          $ref: "#/components/responses/Default401Unauthorized"
+        "403":
+          $ref: "#/components/responses/Default403Forbidden"
+        "406":
+          $ref: "#/components/responses/Default406NotAcceptable"
+        "415":
+          $ref: "#/components/responses/Default415UnsupportedMediaType"
+        "429":
+          $ref: "#/components/responses/Default429TooManyRequests"
+        default:
+          $ref: "#/components/responses/Default500InternalServerError"
+
+  "/report-api/v2/hybrid-flow/client/redirect-to-server":
+    post:
+      tags:
+        - Hybrid Flow API
+      summary: Inclusão de report Hybrid Flow de redirecionamento para o servidor (papel client)
+      description: |
+        Inclusão do report de início de redirecionamento de um usuário do receptor/iniciador para a transmissora/detentora. Ao enviar um report, a Plataforma vai fazer o processo de validação de maneira síncrona e devolver o resultado dessa validação na resposta. O status HTTP de retorno será 200 caso o report enviado seja aceito. Caso seja obtido um status HTTP diferente, a integração deve ser corrigida. Observe no response body o detalhamento do erro e corrija a implementação.
+      operationId: add-reports-client-redirect-to-server
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/HybridFlowClientRedirectToServerReportRequest"
+            examples:
+              "Request Válido":
+                description: O request apresentado tem todos os campos validados.
+
+        required: true
+      responses:
+        "200":
+          description: |
+            O status 200 representa a situação onde  o registro enviado foi validado.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HybridFlowReportResponse"
+              examples:
+                Item processado:
+                  description: Esta seria a resposta para uma solicitação com o exemplo "Request Válido" da documentação.
+        "400":
+          description: O formato do corpo da requisição não é um objeto válido.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GenericError"
+              examples:
+                "400":
+                  value:
+                    message: "Report Invalid"
+
+        "401":
+          $ref: "#/components/responses/Default401Unauthorized"
+        "403":
+          $ref: "#/components/responses/Default403Forbidden"
+        "406":
+          $ref: "#/components/responses/Default406NotAcceptable"
+        "415":
+          $ref: "#/components/responses/Default415UnsupportedMediaType"
+        "429":
+          $ref: "#/components/responses/Default429TooManyRequests"
+        default:
+          $ref: "#/components/responses/Default500InternalServerError"
+
+  "/report-api/v2/hybrid-flow/server/redirect-target":
+    post:
+      tags:
+        - Hybrid Flow API
+      summary: Inclusão de report Hybrid Flow de redirecionamento para o destino (papel server)
+      description: |
+        Inclusão de report de chegada de usuário em sistema da transmissora/dentendora para autenticação. Deve ser enviado antes da autenticação do usuário. Ao enviar um report, a Plataforma vai fazer o processo de validação de maneira síncrona e devolver o resultado dessa validação na resposta. O status HTTP de retorno será 200 caso o reporte enviado seja aceito.
+
+      operationId: add-reports-server-redirect-target
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/HybridFlowServerRedirectTargetReportRequest"
+            examples:
+              "Request Válido":
+                description: O request apresentado tem todos os campos validados.
+        required: true
+      responses:
+        "200":
+          description: |
+            O status 200 representa a situação onde o registro enviado foi validado e será validado. Se o registro contiver problemas de validação.
+            A operação vai devolver um objeto com resultado.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HybridFlowReportResponse"
+
+        "400":
+          description: O formato do corpo da requisição não é um objeto válido.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GenericError"
+              examples:
+                "400":
+                  value:
+                    message: "Report Invalid"
+
+        "401":
+          $ref: "#/components/responses/Default401Unauthorized"
+        "403":
+          $ref: "#/components/responses/Default403Forbidden"
+        "406":
+          $ref: "#/components/responses/Default406NotAcceptable"
+        "415":
+          $ref: "#/components/responses/Default415UnsupportedMediaType"
+        "429":
+          $ref: "#/components/responses/Default429TooManyRequests"
+        default:
+          $ref: "#/components/responses/Default500InternalServerError"
+
+  "/report-api/v2/hybrid-flow/server/authenticated":
+    post:
+      tags:
+        - Hybrid Flow API
+      summary: Inclusão de report Hybrid Flow de autenticação (papel server)
+      description: |
+        Inclusão de report de que o usuário está apto a prosseguir com a autorização do consentimento. Deverá ser enviado após o usuário se autenticar/entrar na área autenticada e antes de autorizar o consentimento. É ESSENCIAL A LEITURA DO DIAGRAMA DE SEQUÊNCIA PARA O ENTENDIMENTO DE COMO DEVE SER FEITO O REPORTE. Ao enviar um reporte, a Plataforma vai fazer o processo de validação de maneira síncrona e devolver o resultado dessa validação na resposta. O status HTTP de retorno será 200 caso o reporte enviado seja aceito.
+      operationId: add-reports-server-authenticated
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/HybridFlowServerAuthenticatedRequest"
+            examples:
+              "Request Válido":
+                description: O request apresentado tem todos os campos validados.
+
+        required: true
+      responses:
+        "200":
+          description: |
+            O status 200 representa a situação onde  o registro enviado foi validado.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HybridFlowReportResponse"
+              examples:
+                Item processado:
+                  description: Esta seria a resposta para uma solicitação com o exemplo "Request Válido" da documentação.
+        "400":
+          description: O formato do corpo da requisição não é um objeto válido.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GenericError"
+              examples:
+                "400":
+                  value:
+                    message: "Report Invalid"
+
+        "401":
+          $ref: "#/components/responses/Default401Unauthorized"
+        "403":
+          $ref: "#/components/responses/Default403Forbidden"
+        "406":
+          $ref: "#/components/responses/Default406NotAcceptable"
+        "415":
+          $ref: "#/components/responses/Default415UnsupportedMediaType"
+        "429":
+          $ref: "#/components/responses/Default429TooManyRequests"
+        default:
+          $ref: "#/components/responses/Default500InternalServerError"
+
+  "/report-api/v2/hybrid-flow/server/redirect-to-client":
+    post:
+      tags:
+        - Hybrid Flow API
+      summary: Inclusão de report Hybrid Flow de redirecionamento para o cliente (papel server)
+      description: |
+        Inclusão de report de redirecionamento do usuário de volta para receptora/iniciadora. Ao enviar um report, a Plataforma vai fazer o processo de validação de maneira síncrona e devolver o resultado dessa validação na resposta. O status HTTP de retorno será 200 caso o reporte enviado seja aceito.
+      operationId: add-reports-server-redirect-to-client
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/HybridFlowServerRedirectToClientRequest"
+
+            examples:
+              "Request Válido":
+                description: O request apresentado tem todos os campos validados.
+
+        required: true
+      responses:
+        "200":
+          description: |
+            O status 200 representa a situação onde  o registro enviado foi validado.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HybridFlowReportResponse"
+              examples:
+                Item processado:
+                  description: Esta seria a resposta para uma solicitação com o exemplo "Request Válido" da documentação.
+        "400":
+          description: O formato do corpo da requisição não é um objeto válido.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GenericError"
+              examples:
+                "400":
+                  value:
+                    message: "Report Invalid"
+
+        "401":
+          $ref: "#/components/responses/Default401Unauthorized"
+        "403":
+          $ref: "#/components/responses/Default403Forbidden"
+        "406":
+          $ref: "#/components/responses/Default406NotAcceptable"
+        "415":
+          $ref: "#/components/responses/Default415UnsupportedMediaType"
+        "429":
+          $ref: "#/components/responses/Default429TooManyRequests"
+        default:
+          $ref: "#/components/responses/Default500InternalServerError"
+
+  "/report-api/v2/hybrid-flow/client/redirect-target-with-errors":
+    post:
+      tags:
+        - Hybrid Flow API
+      summary: Inclusão de report Hybrid Flow de redirecionamento com erro para o destino (papel client)
+      description: |
+        Inclusão do report de retorno do usuário pelo Hybrid Flow contendo o código de erro. Ao enviar um report, a Plataforma vai fazer o processo de validação de maneira síncrona e devolver o resultado dessa validação na resposta. O status HTTP de retorno será 200 caso o reporte enviado seja aceito.
+      operationId: add-reports-client-redirect-target-with-errors
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/HybridFlowServerRedirectTargetWithErrorsRequest"
+
+            examples:
+              "Request Válido":
+                description: O request apresentado tem todos os campos validados.
+
+        required: true
+      responses:
+        "200":
+          description: |
+            O status 200 representa a situação onde  o registro enviado foi validado.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HybridFlowReportResponse"
+              examples:
+                Item processado:
+                  description: Esta seria a resposta para uma solicitação com o exemplo "Request Válido" da documentação.
+        "400":
+          description: O formato do corpo da requisição não é um objeto válido.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GenericError"
+              examples:
+                "400":
+                  value:
+                    message: "Report Invalid"
+
+        "401":
+          $ref: "#/components/responses/Default401Unauthorized"
+        "403":
+          $ref: "#/components/responses/Default403Forbidden"
+        "406":
+          $ref: "#/components/responses/Default406NotAcceptable"
+        "415":
+          $ref: "#/components/responses/Default415UnsupportedMediaType"
+        "429":
+          $ref: "#/components/responses/Default429TooManyRequests"
+        default:
+          $ref: "#/components/responses/Default500InternalServerError"
+
+  "/report-api/v2/hybrid-flow/client/redirect-target-without-errors":
+    post:
+      tags:
+        - Hybrid Flow API
+      summary: Inclusão de report Hybrid Flow de redirecionamento sem erro para o destino (papel client)
+      description: |
+        Inclusão de report de retorno de usuário pelo Hybrid Flow com sucesso. Ao enviar um report, a Plataforma vai fazer o processo de validação de maneira síncrona e devolver o resultado dessa validação na resposta. O status HTTP de retorno será 200 caso o reporte enviado seja aceito.
+      operationId: add-reports-client-redirect-target-without-errors
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/HybridFlowServerRedirectTargetWithoutErrorsRequest"
+
+            examples:
+              "Request Válido":
+                description: O request apresentado tem todos os campos validados.
+
+        required: true
+      responses:
+        "200":
+          description: |
+            O status 200 representa a situação onde  o registro enviado foi validado.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HybridFlowReportResponse"
+              examples:
+                Item processado:
+                  description: Esta seria a resposta para uma solicitação com o exemplo "Request Válido" da documentação.
+        "400":
+          description: O formato do corpo da requisição não é um objeto válido.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GenericError"
+              examples:
+                "400":
+                  value:
+                    message: "Report Invalid"
+
+        "401":
+          $ref: "#/components/responses/Default401Unauthorized"
+        "403":
+          $ref: "#/components/responses/Default403Forbidden"
+        "406":
+          $ref: "#/components/responses/Default406NotAcceptable"
+        "415":
+          $ref: "#/components/responses/Default415UnsupportedMediaType"
+        "429":
+          $ref: "#/components/responses/Default429TooManyRequests"
+        default:
+          $ref: "#/components/responses/Default500InternalServerError"
+
+  "/report-api/v1/private/report/{fapiInteractionId}":
+    get:
+      tags:
+        - Private API
+      summary: Consulta um report em específico usando um identificador
+      description: |
+        Operação que permite a consulta de um reporte em específico mediante um identificador. A busca por reportes estará sempre no contexto do usuário representado pelo token de acesso, ou seja, o _participante_ só terá acesso a reportes em que instituição que ele pertence é parte, seja como client ou como server.
+
+        O processamento do registro ocorre de maneira assíncrona, o que pode gerar um cenário de consistência eventual: caso a consulta seja feita imediatamente após a inclusão, é possível que o registro ainda não esteja disponível para consulta.
+      operationId: private-fapi-interaction-id
+      parameters:
+        - name: fapiInteractionId
+          description: Identificador do reporte que está sendo consultado
+          in: path
+          required: true
+          schema:
+            type: string
+            pattern: ^[- /:_.',0-9a-zA-Z]{0,100}$
+            maxLength: 100
+      responses:
+        "200":
+          description: Consulta realizada com sucesso
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReportModel"
+        "404":
+          description: O registro com o identificador informado não foi encontrado.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GenericError"
+        "401":
+          $ref: "#/components/responses/Default401Unauthorized"
+        "403":
+          $ref: "#/components/responses/Default403Forbidden"
+        "406":
+          $ref: "#/components/responses/Default406NotAcceptable"
+        "429":
+          $ref: "#/components/responses/Default429TooManyRequests"
+        default:
+          $ref: "#/components/responses/Default500InternalServerError"
+    
+  "/report-api/v1/opendata/report":
+    post:
+      tags:
+        - Opendata API
+      summary: Inclusão de reportes
+      description: |
+
+        Inclusão de reportes de dados abertos na plataforma. Ao enviar um lote de reportes, a plataforma vai fazer o processo de validação sintática de cada reporte de maneira síncrona e devolver o resultado dessa validação na resposta. O status HTTP de retorno será 200 caso **todos** dos reportes enviados forem aceitos. Caso pelo menos 1 reporte esteja inconsistente, o status de retorno será 207 - veja documentação de cada status de retorno para mais informações. 
+
+        Os dados inseridos na API de Reporte são sempre processados de maneira assíncrona, e sua persistência se utiliza de consistência posterior (eventual consistency), portanto, um registro tem um tempo de processamento em que ele não estará disponível para consulta até que ele seja persistido.
+
+        O limite de registros de cada lote é de 5.000 registros.
+      operationId: add-opendata-reports
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              maxItems: 5000
+              items:
+                $ref: "#/components/schemas/OpendataReportRequest"
+
+            examples:
+              "Request Valido":
+                description: O request apresentado tem todos os campos validados.
+                value:
+                  - timestamp: "2021-11-11T18:08:08.468Z"
+                    endpoint: "/open-banking/products-services/v1/business-financings"
+                    statusCode: 200
+                    httpMethod: GET
+                    processTimespan: 120
+                    additionalInfo:
+                      clientIp: 192.168.10.10
+                  - timestamp: "2021-11-11T19:22:10.396Z"
+                    endpoint: "/open-banking/products-services/v1/business-financings"
+                    statusCode: 200
+                    httpMethod: GET
+                    processTimespan: 117
+                    additionalInfo:
+                      clientIp: 192.168.10.11
+        required: true
+      responses:
+        "200":
+          description: |
+            O status 200 representa a situação onde todos os registros enviados no lote foram validados e serão direcionados para processamento. Se pelo menos 1 registro contiver problemas de validação, o retorno será 207 (veja descrição do status).
+
+            A operação vai devolver um array com todos os resultados, e garante que ele esteja na mesma ordem do array da requisição.
+          content:
+            application/json:
+              schema:
+                type: array
+                maxItems: 5000
+                items:
+                  $ref: "#/components/schemas/ReportResponse"
+              examples:
+                Todos Processados:
+                  description: Esta seria a resposta para uma solicitação com o exemplo "Request Válido" da documentação. O payload da resposta vem na mesma ordem do array da solicitação. Todos registros que chegarem com o atributo _correlationId_ o receberão de volta. Uma vez que todos os registros foram validados, o status de retorno é o 200.
+                  value:
+                    - reportId: 424ad55c-36cc-4077-b85e-c22ea984cc4a
+                      status: ACCEPTED
+                    - reportId: 4095388d-f44f-499a-a9a7-2dbffce1bb8a
+                      status: ACCEPTED
+
+        "207":
+          description: |
+            O status 207 (Multi-Status) informa ao solicitante que o formato da solicitação está correto, mas que entradas do array da solicitação contém erro de validação em pelo menos uma entrada. Ou seja, se todos os elementos do array informado estiverem com falha de validação, a operação vai devolver o status 207, e no corpo da resposta todos os elementos do array vão estar com status `DISCARDED` e com sua respectiva mensagem. 
+
+            A operação vai devolver um array com todos os resultados, e garante que ele esteja na mesma ordem do array da requisição.
+          content:
+            application/json:
+              schema:
+                type: array
+                maxItems: 5000
+                items:
+                  $ref: "#/components/schemas/ReportResponse"
+              examples:
+                "Primeiro registro com falha":
+                  description: |
+                    No caso apresentado é o resultado onde o exemplo "Request com falha" foi enviado: o registro com o _fapiInteractionId_ `d78fc4e5-37ca-4da3-adf2-9b082bf92280` apresentou uma falha na validação, mas os demais foram enviados para processamento. Como um dos registros não foi validado, o status de retorno passa a ser 207, e os demais registros são processados normalmente.
+                  value:
+                    - reportId: 424ad55c-36cc-4077-b85e-c22ea984cc4a
+                      status: DISCARDED
+                      message: "Missing fields: 'uri'"
+                    - reportId: 4095388d-f44f-499a-a9a7-2dbffce1bb8a
+                      status: ACCEPTED
+                    - reportId: 0f3fcceb-39f6-41b4-a75d-8444244bd836
+                      status: ACCEPTED
+                "Todos registros com falha":
+                  description: |
+                    Neste caso, parte-se da premissa que todos os registros foram enviados com algum campo faltante. Nesse caso, todos vão falhar na etapa de validação, mas mesmo quando todos os registros falham, o status de retorno é o 207.
+                  value:
+                    - reportId: 424ad55c-36cc-4077-b85e-c22ea984cc4a
+                      status: DISCARDED
+                      message: "Missing fields: 'uri'"
+                    - reportId: 4095388d-f44f-499a-a9a7-2dbffce1bb8a
+                      status: DISCARDED
+                      message: "Missing fields: 'additionalInfo'"
+                    - reportId: 0f3fcceb-39f6-41b4-a75d-8444244bd836
+                      status: DISCARDED
+                      message: "Missing fields: 'httpMethod'"
+
+        "400":
+          description: O formato do corpo da requisição não é um array.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GenericError"
+              examples:
+                "400":
+                  value:
+                    message: "Invalid payload format: MUST be an array"
+
+        "413":
+          description: A quantidade de registros enviado excede o limite da operação, ou o tamanho do payload excede o limite configurado no servidor http.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GenericError"
+              examples:
+                "Limite de registros excedido":
+                  value:
+                    message: Record limit exceeded
+
+        "401":
+          $ref: "#/components/responses/Default401Unauthorized"
+        "403":
+          $ref: "#/components/responses/Default403Forbidden"
+        "406":
+          $ref: "#/components/responses/Default406NotAcceptable"
+        "415":
+          $ref: "#/components/responses/Default415UnsupportedMediaType"
+        "429":
+          $ref: "#/components/responses/Default429TooManyRequests"
+        default:
+          $ref: "#/components/responses/Default500InternalServerError"
+
+  "/report-api/v1/consents/stock":
+    post:
+      tags:
+        - Consents API
+      summary: Gerencia informações referentes ao estoque de consentimentos ativos
+      description: |
+        API dedicada à obtenção de estoque de consentimentos, a partir do autorreporte das instituições, com endpoint único para os papeis Client/Server. Registra a quantidade total de estoque de consentimentos ativos até a data de referência, assegurando que a quantidade de consentimentos únicos para PF/PJ não exceda a quantidade de consentimentos ativos. Deve-se garantir o envio diários dos dados relativos a uma data de referência até 08h00 do dia seguinte. 
+      operationId: add-consents-reports
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ConsentStockRequest"
+
+            examples:
+              "Request Valido":
+                description: O request apresentado tem todos os campos validados.
+                value:
+                  date: "2021-11-11"
+                  orgId: "d78fc4e5-37ca-4da3-adf2-9b082bf92280"
+                  role: CLIENT
+                  scope: "DADOS"
+                  totalCustomerPF: 10
+                  totalCustomerPJ: 10
+                  consentsStockList: 
+                    - clientOrgId: "082ff90b-9d65-46bb-b123-b88eb47fd61c"
+                      serverOrgId: "b8e34d5a-2ed5-451e-8ddb-45a1edc76243"
+                      totalActiveConsents: 222
+                    - clientOrgId: "082ff90b-9d65-46bb-b123-b88eb47fd61c"
+                      serverOrgId: "b8e34d5a-2ed5-451e-8ddb-45a1edc76243"
+                      totalActiveConsents: 223
+        required: true
+      responses:
+        "200":
+          description: |
+            O status 200 representa a situação onde todos os registros enviados no lote foram validados e serão direcionados para processamento. Se pelo menos 1 registro contiver problemas de validação, o retorno será 207 (veja descrição do status).
+
+            A operação vai devolver um array com todos os resultados, e garante que ele esteja na mesma ordem do array da requisição.
+          content:
+            application/json:
+              schema:
+                type: array
+                maxItems: 5000
+                items:
+                  $ref: "#/components/schemas/ReportResponse"
+              examples:
+                Todos Processados:
+                  description: Esta seria a resposta para uma solicitação com o exemplo "Request Válido" da documentação. O payload da resposta vem na mesma ordem do array da solicitação. Uma vez que todos os registros foram validados, o status de retorno é o 200.
+                  value:
+                    reportId: 424ad55c-36cc-4077-b85e-c22ea984cc4a
+                    status: ACCEPTED
+
+        "207":
+          description: |
+            O status 207 (Multi-Status) informa ao solicitante que o formato da requisição está correto, mas que entradas do array contém erro de validação em pelo menos 1 item. Ou seja, se todos os elementos do array informado estiverem com falha de validação, a operação vai devolver o status 207, e no corpo da resposta todos os elementos do array vão estar com status `DISCARDED` e com sua respectiva mensagem. 
+
+            A operação vai devolver um array com todos os resultados, e garante que ele esteja na mesma ordem do array da requisição.
+          content:
+            application/json:
+              schema:
+                type: array
+                maxItems: 5000
+                items:
+                  $ref: "#/components/schemas/ReportResponse"
+              examples:
+                "Primeiro registro com falha":
+                  description: |
+                    No caso apresentado é o resultado onde o exemplo "Request com falha" foi enviado: o registro com o _fapiInteractionId_ `d78fc4e5-37ca-4da3-adf2-9b082bf92280` apresentou uma falha na validação, mas os demais foram enviados para processamento. Como um dos registros não foi validado, o status de retorno passa a ser 207, e os demais registros são processados normalmente.
+                  value:
+                    reportId: 424ad55c-36cc-4077-b85e-c22ea984cc4a
+                    status: DISCARDED
+                    message: "Invalid field value, httpMethod: httpMethod must be in enum"
+                "Todos registros com falha":
+                  description: |
+                    Neste caso, parte-se da premissa que todos os registros foram enviados sem _correlationId_ e sem _uri_. Nesse caso, todos vão falhar na etapa de validação, mas mesmo quando todos os registros falham, o status de retorno é o 207.
+                  value:
+                    - reportId: 424ad55c-36cc-4077-b85e-c22ea984cc4a
+                      status: DISCARDED
+                      message: "Missing fields: 'fapiInteractionId'"
+                    - reportId: 4095388d-f44f-499a-a9a7-2dbffce1bb8a
+                      status: DISCARDED
+                      message: "Missing fields: 'fapiInteractionId'"
+                    - reportId: 0f3fcceb-39f6-41b4-a75d-8444244bd836
+                      status: DISCARDED
+                      message: "Missing fields: 'fapiInteractionId'"
+                "Campo obrigatório não enviado":
+                  description: |
+                    Registro com campo obrigatório não enviado.
+                  value:
+                    - reportId: 424ad55c-36cc-4077-b85e-c22ea984cc4a,
+                      correlationId: wNupARo7I9E2PLJZph18a0M9y7DcUe7ITt3DqUOJd9NVjnskxf,
+                      status: DISCARDED,
+                      message: "Missing fields: 'statusCode'"
+
+        "400":
+          description: O formato do corpo da requisição não é um array.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GenericError"
+              examples:
+                "400":
+                  value:
+                    message: "Invalid payload format: MUST be an array"
+
+        "413":
+          description: A quantidade de registros enviado excede o limite da operação (5.000 elementos no array), ou o tamanho do payload excede 10Mb.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GenericError"
+              examples:
+                "Limite de registros excedido":
+                  value:
+                    message: Record limit exceeded
+
+        "401":
+          $ref: "#/components/responses/Default401Unauthorized"
+        "403":
+          $ref: "#/components/responses/Default403Forbidden"
+        "406":
+          $ref: "#/components/responses/Default406NotAcceptable"
+        "415":
+          $ref: "#/components/responses/Default415UnsupportedMediaType"
+        "429":
+          $ref: "#/components/responses/Default429TooManyRequests"
+        default:
+          $ref: "#/components/responses/Default500InternalServerError"
+
+  "/report-api/v1/credit-portabilities/client":
+    post:
+      tags:
+        - Credit Portability API
+      summary: "Inclusão de reports de portabilidade"
+      description: |
+        Valida se já existe um pedido de portabilidade de crédito para o contrato solicitado pelo trilho do OFB ou da Registradora.
+      operationId: add-portability-client-reports
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              maxItems: 5000
+              items:
+                $ref: "#/components/schemas/CreditPortabilityClientRequest"
+
+            examples:
+              "Request Valido":
+                description: O request apresentado tem todos os campos validados.
+                value:
+                  - timestamp: "2021-11-11T18:08:08.278Z" 
+                    fapiInteractionId: "d78fc4e5-37ca-4da3-adf2-9b082bf92280"
+                    clientSSId: "ca0d518b-0e95-42d4-9fc8-0598ff9023af"
+                    clientOrgId: "e6e7c657-4d6d-46d9-a78b-76cc02495cf5"
+                    serverOrgId: "c3779651-c918-48b1-b1fb-e36ba76cb036"
+                    endpoint: "/credit-operations/{contractId}/portability-eligibility"
+                    statusCode: 200
+                    httpMethod: POST
+                    correlationId: "uGQHwNupARo7I9E2PLJZph18a0M9y7DcUe7ITt3DqUOJd9NVjnskxf2"
+                    processTimespan: 120
+                    endpointUriPrefix: "https://openbanking.instituicao-1.com.br/opbk"
+                    role: "CLIENT"
+                    portabilityId: "54d5348c-1a3f-4ff4-a8a8-d0724fb806c6"
+                    contractId: "92792126019929279212650822221989319252576"
+                    creationDateTime: "2020-07-21T08:30:00Z"
+                    productSubTypeCategory: "CREDITO_PESSOAL_CLEAN"
+                    originalContractCET: "0.290000"
+                    originalPropositionCET: "0.290000"
+                    originalContractTerm: 57
+                    propositionTerm: 30
+                    creditPortabilityStatus: "PENDING"
+                    statusUpdateDateTime: "2020-07-21T08:30:00Z"
+                    rejectionReason: "CANCELADO_PELO_CLIENTE"
+                    rejectedBy: "PROPONENTE"
+                  - timestamp: "2021-11-11T18:08:08.278Z" 
+                    fapiInteractionId: "d78fc4e5-37ca-4da3-adf2-9b082bf92280"
+                    clientSSId: "ca0d518b-0e95-42d4-9fc8-0598ff9023af"
+                    clientOrgId: "e6e7c657-4d6d-46d9-a78b-76cc02495cf5"
+                    serverOrgId: "c3779651-c918-48b1-b1fb-e36ba76cb036"
+                    endpoint: "/credit-operations/{contractId}/portability-eligibility"
+                    statusCode: 200
+                    httpMethod: POST
+                    correlationId: "uGQHwNupARo7I9E2PLJZph18a0M9y7DcUe7ITt3DqUOJd9NVjnskxf2"
+                    processTimespan: 120
+                    endpointUriPrefix: "https://openbanking.instituicao-1.com.br/opbk"
+                    role: "CLIENT"
+                    portabilityId: "54d5348c-1a3f-4ff4-a8a8-d0724fb806c6"
+                    contractId: "92792126019929279212650822221989319252576"
+                    creationDateTime: "2020-07-21T08:30:00Z"
+                    productSubTypeCategory: "CREDITO_PESSOAL_CLEAN"
+                    originalContractCET: "0.290000"
+                    originalPropositionCET: "0.290000"
+                    originalContractTerm: 57
+                    propositionTerm: 30
+                    creditPortabilityStatus: "PENDING"
+                    statusUpdateDateTime: "2020-07-21T08:30:00Z"
+                    rejectionReason: "CANCELADO_PELO_CLIENTE"
+                    rejectedBy: "PROPONENTE"
+                  - timestamp: "2021-11-11T18:08:08.278Z" 
+                    fapiInteractionId: "d78fc4e5-37ca-4da3-adf2-9b082bf92280"
+                    clientSSId: "ca0d518b-0e95-42d4-9fc8-0598ff9023af"
+                    clientOrgId: "e6e7c657-4d6d-46d9-a78b-76cc02495cf5"
+                    serverOrgId: "c3779651-c918-48b1-b1fb-e36ba76cb036"
+                    endpoint: "/credit-operations/{contractId}/portability-eligibility"
+                    statusCode: 200
+                    httpMethod: POST
+                    correlationId: "uGQHwNupARo7I9E2PLJZph18a0M9y7DcUe7ITt3DqUOJd9NVjnskxf2"
+                    processTimespan: 120
+                    endpointUriPrefix: "https://openbanking.instituicao-1.com.br/opbk"
+                    role: "CLIENT"
+                    portabilityId: "54d5348c-1a3f-4ff4-a8a8-d0724fb806c6"
+                    contractId: "92792126019929279212650822221989319252576"
+                    creationDateTime: "2020-07-21T08:30:00Z"
+                    productSubTypeCategory: "CREDITO_PESSOAL_CLEAN"
+                    originalContractCET: "0.290000"
+                    originalPropositionCET: "0.290000"
+                    originalContractTerm: 57
+                    propositionTerm: 30
+                    creditPortabilityStatus: "PENDING"
+                    statusUpdateDateTime: "2020-07-21T08:30:00Z"
+                    rejectionReason: "CANCELADO_PELO_CLIENTE"
+                    rejectedBy: "PROPONENTE"
+                  - timestamp: "2021-11-11T18:08:08.278Z" 
+                    fapiInteractionId: "d78fc4e5-37ca-4da3-adf2-9b082bf92280"
+                    clientSSId: "ca0d518b-0e95-42d4-9fc8-0598ff9023af"
+                    clientOrgId: "e6e7c657-4d6d-46d9-a78b-76cc02495cf5"
+                    serverOrgId: "c3779651-c918-48b1-b1fb-e36ba76cb036"
+                    endpoint: "/credit-operations/{contractId}/portability-eligibility"
+                    statusCode: 200
+                    httpMethod: POST
+                    correlationId: "uGQHwNupARo7I9E2PLJZph18a0M9y7DcUe7ITt3DqUOJd9NVjnskxf2"
+                    processTimespan: 120
+                    endpointUriPrefix: "https://openbanking.instituicao-1.com.br/opbk"
+                    role: "CLIENT"
+                    portabilityId: "54d5348c-1a3f-4ff4-a8a8-d0724fb806c6"
+                    contractId: "92792126019929279212650822221989319252576"
+                    creationDateTime: "2020-07-21T08:30:00Z"
+                    productSubTypeCategory: "CREDITO_PESSOAL_CLEAN"
+                    originalContractCET: "0.290000"
+                    originalPropositionCET: "0.290000"
+                    originalContractTerm: 57
+                    propositionTerm: 30
+                    creditPortabilityStatus: "PENDING"
+                    statusUpdateDateTime: "2020-07-21T08:30:00Z"
+                    rejectionReason: "CANCELADO_PELO_CLIENTE"
+                    rejectedBy: "PROPONENTE"
+
+      responses:
+        "200":
+          description: |
+            O status 200 representa a situação onde todos os registros enviados no lote foram validados e serão direcionados para processamento. Se pelo menos 1 registro contiver problemas de validação, o retorno será 207 (veja descrição do status).
+
+            A operação vai devolver um array com todos os resultados, e garante que ele esteja na mesma ordem do array da requisição.
+          content:
+            application/json:
+              schema:
+                type: array
+                maxItems: 5000
+                items:
+                  $ref: "#/components/schemas/ReportResponse"
+              examples:
+                Todos Processados:
+                  description: Esta seria a resposta para uma solicitação com o exemplo "Request Válido" da documentação. O payload da resposta vem na mesma ordem do array da solicitação. Uma vez que todos os registros foram validados, o status de retorno é o 200.
+                  value:
+                    - reportId: 424ad55c-36cc-4077-b85e-c22ea984cc4a
+                      correlationId: 424ad55c-36cc-4077-b85e-c22ea984cc4a
+                      status: ACCEPTED
+                    - reportId: 424ad55c-36cc-4077-b85e-c22ea984cc4a
+                      correlationId: 424ad55c-36cc-4077-b85e-c22ea984cc4a
+                      status: ACCEPTED
+                    - reportId: 424ad55c-36cc-4077-b85e-c22ea984cc4a
+                      correlationId: 424ad55c-36cc-4077-b85e-c22ea984cc4a
+                      status: ACCEPTED
+
+        "207":
+          description: |
+            O status 207 (Multi-Status) informa ao solicitante que o formato da requisição está correto, mas que entradas do array contém erro de validação em pelo menos 1 item. Ou seja, se todos os elementos do array informado estiverem com falha de validação, a operação vai devolver o status 207, e no corpo da resposta todos os elementos do array vão estar com status `DISCARDED` e com sua respectiva mensagem. 
+
+            A operação vai devolver um array com todos os resultados, e garante que ele esteja na mesma ordem do array da requisição.
+          content:
+            application/json:
+              schema:
+                type: array
+                maxItems: 5000
+                items:
+                  $ref: "#/components/schemas/ReportResponse"
+              examples:
+                "Primeiro registro com falha":
+                  description: |
+                    No caso apresentado é o resultado onde o exemplo "Request com falha" foi enviado: o registro com o _fapiInteractionId_ `d78fc4e5-37ca-4da3-adf2-9b082bf92280` apresentou uma falha na validação, mas os demais foram enviados para processamento. Como um dos registros não foi validado, o status de retorno passa a ser 207, e os demais registros são processados normalmente.
+                  value:
+                    - reportId: 424ad55c-36cc-4077-b85e-c22ea984cc4a
+                      correlationId: 424ad55c-36cc-4077-b85e-c22ea984cc4a
+                      status: DISCARDED
+                      message: "fapiInteractionId must be a UUID"
+                    - reportId: 424ad55c-36cc-4077-b85e-c22ea984cc4a
+                      correlationId: 424ad55c-36cc-4077-b85e-c22ea984cc4a
+                      status: ACCEPTED
+                    - reportId: 424ad55c-36cc-4077-b85e-c22ea984cc4a
+                      correlationId: 424ad55c-36cc-4077-b85e-c22ea984cc4a
+                      status: ACCEPTED
+                "Todos registros com falha":
+                  description: |
+                    Neste caso, parte-se da premissa que todos os registros foram enviados sem _correlationId_ e sem _uri_. Nesse caso, todos vão falhar na etapa de validação, mas mesmo quando todos os registros falham, o status de retorno é o 207.
+                  value:
+                    - reportId: 424ad55c-36cc-4077-b85e-c22ea984cc4a
+                      correlationId: wNupARo7I9E2PLJZph18a0M9y7DcUe7ITt3DqUOJd9NVjnskxf
+                      status: DISCARDED
+                      message: "Missing fields: 'fapiInteractionId'"
+                    - reportId: 4095388d-f44f-499a-a9a7-2dbffce1bb8a
+                      correlationId: 8qPzRL4nBzesCc3H1827UlqqEuTT4F5lN82DuJllcnL5VnnY5j
+                      status: ACCEPTED
+                    - reportId: 0f3fcceb-39f6-41b4-a75d-8444244bd836
+                      status: ACCEPTED
+                "Campo obrigatório não enviado":
+                  description: |
+                    Registro com campo obrigatório não enviado.
+                  value:
+                    - reportId: 424ad55c-36cc-4077-b85e-c22ea984cc4a,
+                      correlationId: wNupARo7I9E2PLJZph18a0M9y7DcUe7ITt3DqUOJd9NVjnskxf,
+                      status: DISCARDED,
+                      message: "Missing fields: 'statusCode'"
+
+        "400":
+          description: O formato do corpo da requisição não é um array.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GenericError"
+              examples:
+                "400":
+                  value:
+                    message: "Invalid payload format: MUST be an array"
+
+        "413":
+          description: A quantidade de registros enviado excede o limite da operação (5.000 elementos no array), ou o tamanho do payload excede 10Mb.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GenericError"
+              examples:
+                "Limite de registros excedido":
+                  value:
+                    message: Record limit exceeded
+
+        "401":
+          $ref: "#/components/responses/Default401Unauthorized"
+        "403":
+          $ref: "#/components/responses/Default403Forbidden"
+        "406":
+          $ref: "#/components/responses/Default406NotAcceptable"
+        "415":
+          $ref: "#/components/responses/Default415UnsupportedMediaType"
+        "429":
+          $ref: "#/components/responses/Default429TooManyRequests"
+        default:
+          $ref: "#/components/responses/Default500InternalServerError"
+
+  "/report-api/v1/credit-portabilities/{fapiInteractionId}":
+    get:
+      tags:
+        - Credit Portability API
+      summary: Consulta um report em específico usando um identificador
+      description: |
+        Operação que permite a consulta de um reporte em específico mediante um identificador. A busca por reportes estará sempre no contexto do usuário representado pelo token de acesso, ou seja, o _participante_ só terá acesso a reportes em que instituição que ele pertence é parte, seja como client ou como server.
+
+        O processamento do registro ocorre de maneira assíncrona, o que pode gerar um cenário de consistência eventual: caso a consulta seja feita imediatamente após a inclusão, é possível que o registro ainda não esteja disponível para consulta.
+      operationId: report-by-id
+      parameters:
+        - name: fapiInteractionId
+          description: Identificador do reporte que está sendo consultado
+          in: path
+          required: true
+          schema:
+            type: string
+            pattern: ^[- /:_.',0-9a-zA-Z]{0,100}$
+            maxLength: 100
+      responses:
+        "200":
+          description: Consulta realizada com sucesso
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreditPortabilityReportModel"
+        "404":
+          description: O registro com o identificador informado não foi encontrado.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GenericError"
+        "401":
+          $ref: "#/components/responses/Default401Unauthorized"
+        "403":
+          $ref: "#/components/responses/Default403Forbidden"
+        "406":
+          $ref: "#/components/responses/Default406NotAcceptable"
+        "429":
+          $ref: "#/components/responses/Default429TooManyRequests"
+        default:
+          $ref: "#/components/responses/Default500InternalServerError"
+
+  "/report-api/v1/credit-portabilities/server":
+    post:
+      tags:
+        - Credit Portability API
+      summary: "Inclusão de reports de portabilidade"
+      description: |
+        Valida se já existe um pedido de portabilidade de crédito para o contrato solicitado pelo trilho do OFB ou da Registradora.
+      operationId: add-portability-server-reports
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: "#/components/schemas/CreditPortabiltyServerRequest"
+
+            examples:
+              "Request Valido":
+                description: O request apresentado tem todos os campos validados.
+                value:
+                  - reportId: 424ad55c-36cc-4077-b85e-c22ea984cc4a
+                    fapiInteractionId: "d78fc4e5-37ca-4da3-adf2-9b082bf92280"
+                    endpoint: "/credit-operations/{contractId}/portability-eligibility"
+                    httpMethod: POST
+                    statusCode: 200
+                    timestamp: "2021-11-11T18:08:08.894Z" 
+                    processTimespan: 120
+                    clientOrgId: "c3779651-c918-48b1-b1fb-e36ba76cb036"
+                    serverOrgId: "5ec47c83-9010-4540-91ad-b820ef0df04a"                  
+                    role: "SERVER"
+                    status: "PENDING"
+                    statusUpdateDateTime: "2020-07-21T08:30:00Z"
+                    rejectionReason: "CANCELED"
+                    rejectedBy: "CREDORA" 
+                  - reportId: 424ad55c-36cc-4077-b85e-c22ea984cc4a
+                    fapiInteractionId: "d78fc4e5-37ca-4da3-adf2-9b082bf92280"
+                    endpoint: "/credit-operations/{contractId}/portability-eligibility"
+                    httpMethod: POST
+                    statusCode: 200
+                    timestamp: "2021-11-11T18:08:08.894Z" 
+                    processTimespan: 120
+                    clientOrgId: "c3779651-c918-48b1-b1fb-e36ba76cb036"
+                    serverOrgId: "5ec47c83-9010-4540-91ad-b820ef0df04a"                   
+                    role: "SERVER"
+                    status: "PENDING"
+                    statusUpdateDateTime: "2020-07-21T08:30:00Z"
+                    rejectionReason: "CANCELED"
+                    rejectedBy: "CREDORA"
+                  - reportId: 424ad55c-36cc-4077-b85e-c22ea984cc4a
+                    fapiInteractionId: "d78fc4e5-37ca-4da3-adf2-9b082bf92280"
+                    endpoint: "/credit-operations/{contractId}/portability-eligibility"
+                    httpMethod: POST
+                    statusCode: 200
+                    timestamp: "2021-11-11T18:08:08.894Z" 
+                    processTimespan: 120
+                    clientOrgId: "c3779651-c918-48b1-b1fb-e36ba76cb036"
+                    serverOrgId: "5ec47c83-9010-4540-91ad-b820ef0df04a"                      
+                    role: "SERVER"
+                    status: "PENDING"
+                    statusUpdateDateTime: "2020-07-21T08:30:00Z"
+                    rejectionReason: "CANCELED"
+                    rejectedBy: "CREDORA"                      
+
+      responses:
+        "200":
+          description: |
+            O status 200 representa a situação onde todos os registros enviados no lote foram validados e serão direcionados para processamento. Se pelo menos 1 registro contiver problemas de validação, o retorno será 207 (veja descrição do status).
+
+            A operação vai devolver um array com todos os resultados, e garante que ele esteja na mesma ordem do array da requisição.
+          content:
+            application/json:
+              schema:
+                type: array
+                maxItems: 5000
+                items:
+                  $ref: "#/components/schemas/ReportResponse"
+              examples:
+                Todos Processados:
+                  description: Esta seria a resposta para uma solicitação com o exemplo "Request Válido" da documentação. O payload da resposta vem na mesma ordem do array da solicitação. Uma vez que todos os registros foram validados, o status de retorno é o 200.
+                  value:
+                    - reportId: 424ad55c-36cc-4077-b85e-c22ea984cc4a
+                      correlationId: 424ad55c-36cc-4077-b85e-c22ea984cc4a
+                      status: ACCEPTED
+                    - reportId: 424ad55c-36cc-4077-b85e-c22ea984cc4a
+                      correlationId: 424ad55c-36cc-4077-b85e-c22ea984cc4a
+                      status: ACCEPTED
+                    - reportId: 424ad55c-36cc-4077-b85e-c22ea984cc4a
+                      correlationId: 424ad55c-36cc-4077-b85e-c22ea984cc4a
+                      status: ACCEPTED
+
+        "207":
+          description: |
+            O status 207 (Multi-Status) informa ao solicitante que o formato da requisição está correto, mas que entradas do array contém erro de validação em pelo menos 1 item. Ou seja, se todos os elementos do array informado estiverem com falha de validação, a operação vai devolver o status 207, e no corpo da resposta todos os elementos do array vão estar com status `DISCARDED` e com sua respectiva mensagem. 
+
+            A operação vai devolver um array com todos os resultados, e garante que ele esteja na mesma ordem do array da requisição.
+          content:
+            application/json:
+              schema:
+                type: array
+                maxItems: 5000
+                items:
+                  $ref: "#/components/schemas/ReportResponse"
+              examples:
+                "Primeiro registro com falha":
+                  description: |
+                    No caso apresentado é o resultado onde o exemplo "Request com falha" foi enviado: o registro com o _fapiInteractionId_ `d78fc4e5-37ca-4da3-adf2-9b082bf92280` apresentou uma falha na validação, mas os demais foram enviados para processamento. Como um dos registros não foi validado, o status de retorno passa a ser 207, e os demais registros são processados normalmente.
+                  value:
+                    - reportId: 424ad55c-36cc-4077-b85e-c22ea984cc4a
+                      correlationId: 424ad55c-36cc-4077-b85e-c22ea984cc4a
+                      status: DISCARDED
+                      message: "Invalid field value, fapiInteractionId: fapiInteractionId must be a UUID"
+                    - reportId: 424ad55c-36cc-4077-b85e-c22ea984cc4a
+                      correlationId: 424ad55c-36cc-4077-b85e-c22ea984cc4a
+                      status: ACCEPTED
+                    - reportId: 424ad55c-36cc-4077-b85e-c22ea984cc4a
+                      correlationId: 424ad55c-36cc-4077-b85e-c22ea984cc4a
+                      status: ACCEPTED
+                "Todos registros com falha":
+                  description: |
+                    Neste caso, parte-se da premissa que todos os registros foram enviados sem _correlationId_ e sem _uri_. Nesse caso, todos vão falhar na etapa de validação, mas mesmo quando todos os registros falham, o status de retorno é o 207.
+                  value:
+                    - reportId: 424ad55c-36cc-4077-b85e-c22ea984cc4a
+                      status: DISCARDED
+                      message: "Missing fields: 'fapiInteractionId'"
+                    - reportId: 4095388d-f44f-499a-a9a7-2dbffce1bb8a
+                      status: DISCARDED
+                      message: "Missing fields: 'fapiInteractionId'"
+                    - reportId: 0f3fcceb-39f6-41b4-a75d-8444244bd836
+                      status: DISCARDED
+                      message: "Missing fields: 'fapiInteractionId'"
+                "Campo obrigatório não enviado":
+                  description: |
+                    Registro com campo obrigatório não enviado.
+                  value:
+                    - reportId: 424ad55c-36cc-4077-b85e-c22ea984cc4a,
+                      correlationId: wNupARo7I9E2PLJZph18a0M9y7DcUe7ITt3DqUOJd9NVjnskxf,
+                      status: DISCARDED,
+                      message: "Missing fields: 'statusCode'"
+
+        "400":
+          description: O formato do corpo da requisição não é um array.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GenericError"
+              examples:
+                "400":
+                  value:
+                    message: "Invalid payload format: MUST be an array"
+
+        "413":
+          description: A quantidade de registros enviado excede o limite da operação (5.000 elementos no array), ou o tamanho do payload excede 10Mb.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GenericError"
+              examples:
+                "Limite de registros excedido":
+                  value:
+                    message: Record limit exceeded
+
+        "401":
+          $ref: "#/components/responses/Default401Unauthorized"
+        "403":
+          $ref: "#/components/responses/Default403Forbidden"
+        "406":
+          $ref: "#/components/responses/Default406NotAcceptable"
+        "415":
+          $ref: "#/components/responses/Default415UnsupportedMediaType"
+        "429":
+          $ref: "#/components/responses/Default429TooManyRequests"
+        default:
+          $ref: "#/components/responses/Default500InternalServerError"
+
+
+components:
+  schemas:
+    Platform:
+      type: string
+      enum:
+        - BROWSER
+        - APP
+      example: BROWSER
+
+    URI:
+      type: string
+      format: uri
+      pattern:  ^[- /:_.',0-9a-zA-Z]{0,200}$
+      maxLength: 200
+
+    Timestamp:
+      description: Data/Hora UTC no formato ISO8601 com milissegundos (YYYY-MM-DDTHH:mm:ss.sssZ) do momento em que a chamada foi disparada, imediatamente antes do primeiro byte enviado na requisição.
+      type: string
+      format: date-time
+      maxLength: 28
+      example: "2021-11-11T18:08:08.278Z"
+
+    ConsentId:
+      type: string
+      pattern: ^urn:[a-zA-Z0-9][a-zA-Z0-9\-]{0,31}:[a-zA-Z0-9()+,\-.:=@;$_!*''%\/?#]+$
+      maxLength: 256
+      example: urn:bancoex:C1DD33123
+      description: |
+
+        O consentId deve ser preenchido com a mesma string do identificador único de um fluxo de consentimento de dados, de pagamento ou de vínculo
+
+        exemplos:    
+        
+          * pós `POST` /open-banking/payments/v4/consents utilizar a string obtida/enviada em data.consentId
+        
+          * pós `POST` /open-banking/consents/v3/consents utilizar a string obtida/enviada em data.consentId
+        
+          * pós `POST` /automatic-payments/v1/recurring-consents utilizar a string obtida/enviada em data.recurringConsentId
+        
+          * pós `POST` /automatic-payments/v1/pix/recurring-payments utilizar a string obtida/enviada em data.recurringConsentId
+        
+          * pós `POST` /open-banking/enrollments/v1/enrollments utilizar a string obtida/enviada em data.enrollmentId
+
+    OSType:
+      type: string
+      example: LINUX
+      enum:
+        - LINUX
+        - MACOS
+        - UNIX
+        - WINDOWS
+        - IOS
+        - ANDROID
+        - OTHER
+
+    HybridFlowClientRedirectToServerReportRequest:
+      description: ""
+      type: array
+      minItems: 0
+      maxItems: 1000
+      items:
+        type: object
+        required:
+          - "consentId"
+          - "platform"
+          - "osVersion"
+          - "os"
+          - "timestamp"
+          - clientOrgId
+        properties:
+          consentId:
+            $ref: "#/components/schemas/ConsentId"
+          uriAuthorizationEndpoint:
+            description: Endpoint utilizado para o redirecionamento do usuário conforme cadastrado pela transmissora/detentora no arquivo .well-known/openid-configuration sem qualquer parâmetro introduzido pelo sistema da receptora/iniciadora. Caso a URI tenha mais de 200 caracteres de extensão, truncar. 
+            type: string
+            format: uri
+            pattern: ^[- /:_.',0-9a-zA-Z]{0,200}$
+            maxLength: 200
+            example: https://auth.banco.com.br/open-banking/Auth
+          platform:
+            type: string
+            enum:
+              - BROWSER
+              - APP
+            example: BROWSER
+          osVersion:
+            type: string
+            example: "20.04"
+          os:
+            type: string
+            example: LINUX
+            enum:
+              - LINUX
+              - MACOS
+              - UNIX
+              - WINDOWS
+              - IOS
+              - ANDROID
+              - OTHER
+          timestamp:
+            description: Data/Hora UTC no formato ISO8601 com milissegundos (YYYY-MM-DDTHH:mm:ss.sssZ) do momento em que a chamada foi disparada, imediatamente antes do primeiro byte enviado na requisição.
+            type: string
+            format: date-time
+            maxLength: 28
+            example: "2021-11-11T18:08:08.278Z"
+          clientOrgId:
+            description: A ser enviado vazio caso o report seja da mesma instituição que obteve o token para uso da PCM e, caso contrário, deve ser preenchido com o organasationId da instituição filha para o qual a instituição mãe está fazendo o report.
+            allOf:
+              - $ref: "#/components/schemas/UUID"
+
+    HybridFlowServerRedirectTargetReportRequest:
+      description: "Inclusão de reporte de chegada de usuário em sistema da transmissora/detentora. É ESSENCIAL A LEITURA DO DIAGRAMA DE SEQUÊNCIA PARA O ENTENDIMENTO DE COMO DEVE SER FEITO O REPORTE. Ao enviar um report, a Plataforma vai fazer o processo de validação de maneira síncrona e devolver o resultado dessa validação na resposta. O status HTTP de retorno será 200 caso o reporte enviado seja aceito."
+      type: array
+      minItems: 0
+      maxItems: 1000
+      items:
+        type: object
+        required:
+          - "consentId"
+          - "osVersion"
+          - "os"
+          - "type"
+          - "timestamp"
+          - serverOrgId
+        properties:
+          consentId:
+            $ref: "#/components/schemas/ConsentId"
+          uriAuthorizationEndpoint:
+            allOf:
+              - description: Endpoint utilizado para o redirecionamento do usuário conforme cadastrado pela transmissora/detentora no arquivo .well-known/openid-configuration sem qualquer parâmetro introduzido pelo sistema da receptora/iniciadora. Caso a URI tenha mais de 200 caracteres de extensão, truncar
+              - $ref: "#/components/schemas/URI"
+              - example: "https://auth.banco.com.br/openbanking/Auth"
+          osVersion:
+            type: string
+            example: "20.04"
+          os:
+            $ref: "#/components/schemas/OSType"
+          type:
+            type: string
+            enum:
+              - AWAITING_HANDOFF
+              - AWAITING_USER_AUTH
+              - AWAITING_REDIRECT_TO_APP
+          timestamp:
+            $ref: "#/components/schemas/Timestamp"
+          serverOrgId:
+            description: A ser enviado vazio caso o report seja da mesma instituição que obteve o token para uso da PCM e, caso contrário, deve ser preenchido com o organasationId da instituição filha para o qual a instituição mãe está fazendo o report.
+            type: string
+            format: uuid
+            maxLength: 36
+            pattern: "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+            example: "c1ca8e62-9d6f-4ea3-84f2-d66bc0a8f7dc"
+
+    HybridFlowServerAuthenticatedRequest:
+      description: ""
+      type: array
+      minItems: 0
+      maxItems: 1000
+      items:
+        type: object
+        required:
+          - "consentId"
+          - "platform"
+          - "osVersion"
+          - "os"
+          - timestamp
+          - serverOrgId
+        properties:
+          consentId:
+            $ref: "#/components/schemas/ConsentId"
+          platform:
+            $ref: "#/components/schemas/Platform"
+          osVersion:
+            type: string
+            example: "20.04"
+          os:
+            $ref: "#/components/schemas/OSType"
+          timestamp:
+            $ref: "#/components/schemas/Timestamp"
+          serverOrgId:
+            description: A ser enviado vazio caso o report seja da mesma instituição que obteve o token para uso da PCM e, caso contrário, deve ser preenchido com o organasationId da instituição filha para o qual a instituição mãe está fazendo o report.
+            type: string
+            format: uuid
+            maxLength: 36
+            pattern: "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+            example: "c1ca8e62-9d6f-4ea3-84f2-d66bc0a8f7dc"
+
+    HybridFlowServerRedirectToClientRequest:
+      description: ""
+      type: array
+      minItems: 0
+      maxItems: 1000
+      items:
+        type: object
+        required:
+          - "consentId"
+          - "uri_callback"
+          - "platform"
+          - "osVersion"
+          - "os"
+          - "type"
+          - "timestamp"
+          - serverOrgId
+        properties:
+          consentId:
+            $ref: "#/components/schemas/ConsentId"
+          uri_callback:
+            allOf:
+              - description: Preencher com a uri_callback registrada pelo sistema consumidor durante o DCR/DCM. Caso a URI tenha mais de 200 caracteres de extensão, truncar.
+              - $ref: "#/components/schemas/URI"
+              - example: "https://receptora.com.br/open-banking/landing-page"
+          platform:
+            $ref: "#/components/schemas/Platform"
+          osVersion:
+            type: string
+            example: "20.04"
+          os:
+            $ref: "#/components/schemas/OSType"
+          type:
+            type: string
+            enum:
+              - AUTHORISED
+              - REJECTED
+          timestamp:
+            $ref: "#/components/schemas/Timestamp"
+          serverOrgId:
+            description: A ser enviado vazio caso o report seja da mesma instituição que obteve o token para uso da PCM e, caso contrário, deve ser preenchido com o organasationId da instituição filha para o qual a instituição mãe está fazendo o report.
+            type: string
+            format: uuid
+            maxLength: 36
+            pattern: "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+            example: "c1ca8e62-9d6f-4ea3-84f2-d66bc0a8f7dc"
+
+    HybridFlowServerRedirectTargetWithoutErrorsRequest:
+      description: ""
+      type: array
+      minItems: 0
+      maxItems: 1000
+      items:
+        type: object
+        required:
+          - "consentId"
+          - "platform"
+          - "osVersion"
+          - "os"
+          - timestamp
+          - clientOrgId
+        properties:
+          consentId:
+            $ref: "#/components/schemas/ConsentId"
+          platform:
+            $ref: "#/components/schemas/Platform"
+          osVersion:
+            type: string
+            example: "20.04"
+          os:
+            $ref: "#/components/schemas/OSType"
+          timestamp:
+            $ref: "#/components/schemas/Timestamp"
+          clientOrgId:
+            description: A ser enviado vazio caso o report seja da mesma instituição que obteve o token para uso da PCM e, caso contrário, deve ser preenchido com o organasationId da instituição filha para o qual a instituição mãe está fazendo o report.
+            allOf:
+            - $ref: "#/components/schemas/UUID"
+
+    HybridFlowServerRedirectTargetWithErrorsRequest:
+      description: ""
+      type: array
+      minItems: 0
+      maxItems: 1000
+      items:
+        type: object
+        required:
+          - "consentId"
+          - "platform"
+          - "osVersion"
+          - "os"
+          - "error"
+          - "timestamp"
+          - clientOrgId
+        properties:
+          consentId:
+            $ref: "#/components/schemas/ConsentId"
+          platform:
+            $ref: "#/components/schemas/Platform"
+          osVersion:
+            type: string
+            example: "20.04"
+          os:
+            $ref: "#/components/schemas/OSType"
+          error:
+            type: string
+            example: "Código de erro retornado no payload do Hybrid Flow"
+          timestamp:
+            $ref: "#/components/schemas/Timestamp"
+          clientOrgId:
+            description: A ser enviado vazio caso o report seja da mesma instituição que obteve o token para uso da PCM e, caso contrário, deve ser preenchido com o organasationId da instituição filha para o qual a instituição mãe está fazendo o report.
+            allOf:
+            - $ref: "#/components/schemas/UUID"
+
+    ClientReportRequest:
+      description: Representa os dados que deverão ser enviados para a inclusão de reportes pelo lado do Client (iniciador da chamada). Informações adicionais sobre cada campo podem ser encontradas na documentação funcional em [https://openfinancebrasil.atlassian.net/wiki/spaces/OF/pages/37879861/Reporte#Modelos-para-reportes-Private](https://openfinancebrasil.atlassian.net/wiki/spaces/OF/pages/37879861/Reporte#Modelos-para-reportes-Private)
+      type: array
+      minItems: 1
+      maxItems: 5000
+      items:
+        type: object
+        required:
+          - endpoint
+          - statusCode
+          - httpMethod
+          - additionalInfo
+          - timestamp
+          - processTimespan
+          - clientSSId
+          - clientOrgId
+          - serverOrgId
+          - endpointUriPrefix
+          - role
+        properties:
+          fapiInteractionId:
+            description: UUID que identifica uma transação específica entre dois participantes. Esse dado pode ser encontrado no header x-fapi-interaction-id informado pelo Client e devolvido pelo Server. Mais informações em [Cabeçalhos HTTP](https://openbanking-brasil.github.io/areadesenvolvedor/#cabecalhos-http) na documentação do Open Finance Brasil. O envio dessa informação é obrigatório, exceto nos casos ontem ela não esteja disponível como, por exemplo, em respostas com status 5xx, ou em chamadas que terminaram por timeout onde o reporte tem que ser enviado, mas sem esse atributo. Nos demais cenários, o envio é obrigatório.
+            type: string
+            format: uuid
+            maxLength: 36
+            pattern: "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+            example: "d78fc4e5-37ca-4da3-adf2-9b082bf92280"
+          endpoint:
+            $ref: "#/components/schemas/PrivateReportEndpoints"
+          statusCode:
+            description: Status de retorno HTTP da solicitação. No caso de ocorrer um timeout client side preencher com um código 403 (conforme documentação ).
+            type: integer
+            format: int32
+            example: 200
+            minimum: 200
+            maximum: 599
+          httpMethod:
+            description: Método HTTP da solicitação.
+            type: string
+            enum: ["GET", "POST", "PUT", "DELETE", "PATCH"]
+            example: GET
+          correlationId:
+            description: ID de correlação que identifica uma sequência de chamadas inter-relacionadas no ecossistema. Diferente do fapiInteractionId que serve para identificar cada par request-response (interação), o identificador de correlação serve para ligar diferentes reportes quando estes representam uma jornada ou uma sequência de chamadas. Este valor é de livre provimento pelo reportador.
+            type: string
+            pattern: ^[- /:_.',0-9a-zA-Z]{0,100}$
+            maxLength: 100
+            example: "uGQHwNupARo7I9E2PLJZph18a0M9y7DcUe7ITt3DqUOJd9NVjnskxf2"
+          additionalInfo:
+            description: Informações adicionais sobre o reporte deste endpoint/método. Possui característica variável. As regras de preenchimento estão na documentação funcional em [openfinancebrasil](https://openfinancebrasil.atlassian.net/wiki/spaces/OF/pages/806158355/Planilha+AdditionalInfo). Atenção especial na tabela Excel com a listagem de endpoints em [https://openfinancebrasil.atlassian.net/wiki/spaces/OF/pages/806158355/Planilha+AdditionalInfo](https://openfinancebrasil.atlassian.net/wiki/spaces/OF/pages/806158355/Planilha+AdditionalInfo)
+            type: object
+            properties:
+              consentId:
+                description: Deve ser preenchido com a mesma string obtida no campo `.data.consentId` retornado após a chamada inicial na API "POST /consent". *Ao reportar o uso de um endpoint /token, o identificador único de consentimento só será reportado nos casos em que "grant_type" é do tipo "authorization_code" ou do tipo "refresh_token", uma vez que esta informação de consentId é inexistente quando "grant_type" é do tipo
+                type: string
+              personType:
+                description: Deve ser preenchida baseado no tipo de pessoa responsável pelo consentimento. Deverá ser observado se `.data.businessEntity` estiver preenchido no payload, se estiver então preencher com "PJ", se não estiver então preencher com "PF"
+                type: string
+                enum:
+                  - PF
+                  - PJ
+              localInstrument:
+                description: Deve ser preenchido com a mesma string informada no payload ".data.localInstrument"
+                type: string
+              status:
+                description: Deve ser preenchido com a mesma string obtida no ".data.status"
+                type: string
+              clientIp:
+                description: Deve ser preenchido com o Endereço IPv4 ou IPv6 do client que fez a requisição
+                type: string
+              rejectReason:
+                description: Deve ser preenchido com a mesma string obtida no ".data.rejectionReason.code"
+                type: string
+              errorCodes:
+                description: Caso o HTTP Code seja 4XX ou 5XX, esse campo deve ser preenchido com a lista das strings obtidas em ".errors[].code" . Não havendo string, deve ser enviada uma lista vazia.
+                type: string
+              webhookEnable:
+                description: Deve ser preenchido com o valor booleano TRUE caso haja pelo menos um item indicado na lista do campo ".webhook_uris" no payload, caso contrário deverá ser preenchido com o valor booleano FALSE
+                type: string
+              webhookInteractionId:
+                description: Caso o GET esteja sendo feito após o estímulo do webhook, o x-webhook-interaction-id deverá ser indicado
+                type: string
+              enrollmentId:
+                description: Deve ser preenchido com a mesma string obtida no campo `.data.enrollmentId` retornado após a chamada inicial na API "POST /enrollments". *Ao reportar o uso de um endpoint /token, o identificador único de consentimento só será reportado nos casos em que "grant_type" é do tipo "authorization_code" ou do tipo "refresh_token", uma vez que esta informação de enrollmentId é inexistente quando "grant_type" é do tipo "client_credentials".
+                type: string
+              authenticatorAttachment:
+                description: Deve ser preenchido com a mesma string definida em ".data.authenticatorAttachment".  Não havendo string, deve ser explicitamente enviada esse additionalInfo como sendo uma string vazia.
+                type: string
+              platform:
+                description: Deve ser preenchido com a mesma string definida em ".data.platform"
+                type: string
+              rp:
+                description: Deve ser preenchido com a mesma string definida em ".data.rp"
+                type: string
+              rejectionReasonCode:
+                description: Deve ser preenchido com a mesma string obtida no ".data.rejectionReason.code"
+                type: string
+              rejectionReasonDetail:
+                description: Deve ser preenchido com a mesma string obtida no ".data.rejectionReason.detail"
+                type: string
+              authorisationFlow:
+                description: Deve ser preenchido com a mesma string obtida no ".data.authorisationFlow"
+                type: string
+              paymentType:
+                description: |
+                  Identifica o modo de pagamento acionado no consentimento
+                  1. Envio obrigatório para a role Client​
+                  2. Conteudo ENUM do novo campo varia de acordo com o endpoint conforme tabela abaixo
+
+                  | Endpoint | Valores possíveis |
+                  |----------|-------------|
+                  | <br>POST /open-banking/payments/v4/consents&nbsp;&nbsp;&nbsp;    |  <br>IMMEDIATE<br>SCHEDULED<br>RECURRENT
+                  |----------|-------------|
+                  | <br>POST /open-banking/payments/v4/pix/payments&nbsp;&nbsp;&nbsp;    |  <br>IMMEDIATE<br>SCHEDULED<br>RECURRENT
+                  |----------|-------------|
+                  | <br>PATCH /open-banking/payments/v4/pix/payments/{paymentId}​&nbsp;&nbsp;&nbsp;    |  <br>IMMEDIATE<br>SCHEDULED<br>RECURRENT
+                  |----------|-------------|
+                  | <br>POST /automatic-payments/v1/recurring-consents&nbsp;&nbsp;&nbsp;    |  <br>SWEEPING
+                  |----------|-------------|
+                  | <br>PATCH /automatic-payments/v1/recurring-consents/{consentId}&nbsp;&nbsp;&nbsp;    |  <br>SWEEPING
+                  |----------|-------------|
+                  | <br>POST /automatic-payments/v1/pix/recurring-payments&nbsp;&nbsp;&nbsp;    |  <br>SWEEPING
+                  |----------|-------------|
+                  | <br>PATCH /automatic-payments/v1/pix/recurring-payments/{paymentId}&nbsp;&nbsp;&nbsp;   |  <br>SWEEPING
+                  | <br>POST /open-banking/automatic-payments/v2/recurring-consents&nbsp;&nbsp;&nbsp;   |  <br>SWEEPING<br>AUTOMATIC
+                  |----------|-------------|
+                  | <br>POST /open-banking/automatic-payments/v2/recurring-consents/{recurringConsentId}&nbsp;&nbsp;&nbsp;   |  <br>SWEEPING<br>AUTOMATIC
+                  |----------|-------------|
+                  | <br>POST /open-banking/automatic-payments/v2/pix/recurring-payments&nbsp;&nbsp;&nbsp;   |  <br>SWEEPING<br>AUTOMATIC
+                  |----------|-------------|
+                  | <br>POST /open-banking/automatic-payments/v2/pix/recurring-payments/{recurringPaymentId}&nbsp;&nbsp;&nbsp;   |  <br>SWEEPING<br>AUTOMATIC
+                  |----------|-------------|
+                  | <br>GET /open-banking/automatic-payments/v2/recurring-consents&nbsp;&nbsp;&nbsp;   |  <br>SWEEPING<br>AUTOMATIC
+                  |----------|-------------|
+                  | <br>GET /open-banking/automatic-payments/v2/recurring-consents/{recurringConsentId}&nbsp;&nbsp;&nbsp;   |  <br>SWEEPING<br>AUTOMATIC
+                  |----------|-------------|
+                  | <br>GET /open-banking/automatic-payments/v2/pix/recurring-payments&nbsp;&nbsp;&nbsp;   |  <br>SWEEPING<br>AUTOMATIC
+                  |----------|-------------|
+                  | <br>GET /open-banking/automatic-payments/v2/pix/recurring-payments/{recurringPaymentId}&nbsp;&nbsp;&nbsp;   |  <br>SWEEPING<br>AUTOMATIC
+                  |----------|-------------|
+                  | <br>PATCH /open-banking/automatic-payments/v2/recurring-consents&nbsp;&nbsp;&nbsp;   |  <br>SWEEPING<br>AUTOMATIC
+                  |----------|-------------|
+                  | <br>PATCH /open-banking/automatic-payments/v2/recurring-consents/{recurringConsentId}&nbsp;&nbsp;&nbsp;   |  <br>SWEEPING<br>AUTOMATIC
+                  |----------|-------------|
+                  | <br>PATCH /open-banking/automatic-payments/v2/pix/recurring-payments&nbsp;&nbsp;&nbsp;   |  <br>SWEEPING<br>AUTOMATIC
+                  |----------|-------------|
+                  | <br>PATCH /open-banking/automatic-payments/v2/pix/recurring-payments/{recurringPaymentId}&nbsp;&nbsp;&nbsp;   |  <br>SWEEPING<br>AUTOMATIC
+              
+                  <br>
+                  Identifica o modo de pagamento acionado no consentimento.
+
+                  Valores possíveis:
+                  - `IMMEDIATE`: Pix sem configuração de agendamento
+                  - `SCHEDULED`: Pix com configuração de agendamento
+                  - `RECURRENT`: Pix com agendamento e recorrência
+                  - `SWEEPING`: Chamadas de pagamentos inteligentes
+                  - `AUTOMATIC`: Pagamentos automáticos
+                type: string
+                enum:
+                  - IMMEDIATE
+                  - SCHEDULED
+                  - RECURRENT​
+                  - SWEEPING
+                x-enum-descriptions:
+                  - Pix sem configuração de agendamento​
+                  - Pix com configuração de agendamento​
+                  - Pix sem configuração de agendamento e configuração de recorrência​
+                  - para todas as chamadas de pagamentos inteligentes​
+              dropReason:
+                description: |
+                  Regras:
+                    - O campo dropReason deve ser adicionado nas informações do campo additionalInfo que deverá ser enviado no reporte do provedor do serviço consumido (papel SERVER) 
+                    - O reporte deverá ser feito por todos os transmissores de dados e detentoras de conta. Para os casos em que ocorram falhas técnicas que impossibilitem a verificação do CPF/CNPJ (incluindo, mas não se limitando, a erros HTTP 4xx, 500 ou timeout na resposta), o reporte deve ser realizado com o valor NO_CREDENTIAL, Em jornadas de múltipla alçada de pessoas jurídicas, quando a autenticação é bem-sucedida mas os poderes constituídos são insuficientes para finalização do Hybrid Flow, deve-se usar NO_AUTHORITY.
+                  
+                  Diretrizes:
+
+                    - `NONE`: quando o CPF (loggedUser) / CNPJ (businessEntity) possui credencial autenticadora e poderes suficientes para prosseguir o fluxo monitorado - exemplo: PF, cliente, que possui credencial ativa, mas não se autenticou; cliente que se autenticou utilizando a credencial correta. 
+                    - `NO_CREDENTIAL`: quando o CPF (loggedUser) / CNPJ (businessEntity) não for cliente ou não possuir credencial válida/ativa para prosseguir no fluxo monitorado ou quando o HTTP response code for diferente de 201.
+                    - `NO_AUTHORITY`: quando o CPF (loggedUser) / CNPJ (businessEntity) consegue se autenticar, mas não dispõe de poderes ou alçadas para prosseguir no fluxo de compartilhamento de dados e serviços. 
+                    - `NO_AUTHORITY_PERSON_MISMATCH`: quando o CPF (loggedUser) não possui relação com a credencial utilizada na etapa de autenticação do Hybrid Flow - exemplo: consentimento criado para um CPF e autenticado por outro; criado para um CNPJ e autenticado por CPF sem relação com o CNPJ. 
+                type: string
+              revocationReasonCode:
+                description: |
+                  Código indicador do motivo da revogação
+                  1. Envio obrigatório para a role Client
+
+                  | Endpoint  | Descrição Jornada | Obrigatoriedade Client  | Obrigatoriedade Server  |
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | POST /automatic-payments/v1/recurring-consents                  | Criar consentimento para iniciação de pagamento​                                                                              | -                                    | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | GET /automatic-payments/v1/recurring-consents/{consentId}​       | Consultar consentimento para iniciação de pagamento​​                                                                          | Se revogation: {RevocationReasonCode, RevocationReasonDetail, RevokedBy, RevokedFrom}​ <br> Se rejected: {RejectedBy, RejectedFrom}​        | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | PATCH /automatic-payments/v1/recurring-consents/{consentId}​     | Rejeita, revoga ou edita um consentimento​          ​                                                                          | Se revogation: {RevocationReasonCode, RevocationReasonDetail, RevokedBy, RevokedFrom}​ <br> Se rejected: {RejectedBy, RejectedFrom}​        | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |        
+                  | POST /automatic-payments/v1/pix/recurring-payments​​              | Pix - Criar iniciação de pagamento limitada por parametrização de tempo ou limite total realizada no consentimento​​           | -                                  
+                  | --------- | ----------------- | ----------------------- | ----------------------- |        
+                  | GET /automatic-payments/v1/pix/recurring-payments?consentId=​    | Pix – Consulta informações de transações de pagamentos associadas a um consentimento​                                         | -                                
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | GET /automatic-payments/v1/pix/recurring-payments/{paymentId}​   | Pix - Consultar iniciação de pagamento​                                                                                       | -                                    | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | PATCH /automatic-payments/v1/pix/recurring-payments/{paymentId}​ | Pix - Cancelar iniciação de pagamento​​                                                                                        | Será necessário o reporte porém temos que aguardar a <br> definição do nome do campo pelo GT Especificações Serviços​                      | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | POST /open-banking/automatic-payments/v2/recurring-consents     | Criar consentimento para iniciação de pagamento​                                                                              | -                                    | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | GET /open-banking/automatic-payments/v2/recurring-consents/{recurringConsentId}​       | Consultar consentimento para iniciação de pagamento​​                                                                          | Se revogation: {RevocationReasonCode, RevocationReasonDetail, RevokedBy, RevokedFrom}​ <br> Se rejected: {RejectedBy, RejectedFrom}​        | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | PATCH /open-banking/automatic-payments/v2/recurring-consents/{recurringConsentId}​     | Rejeita, revoga ou edita um consentimento​          ​                                                                          | Se revogation: {RevocationReasonCode, RevocationReasonDetail, RevokedBy, RevokedFrom}​ <br> Se rejected: {RejectedBy, RejectedFrom}​        | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |        
+                  | POST /open-banking/automatic-payments/v2/pix/recurring-payments​​              | Pix - Criar iniciação de pagamento limitada por parametrização de tempo ou limite total realizada no consentimento​​           | -                                  
+                  | --------- | ----------------- | ----------------------- | ----------------------- |        
+                  | GET /open-banking/automatic-payments/v2/pix/recurring-payments/{recurringPaymentId}​   | Pix - Consultar iniciação de pagamento​                                                                                       | -                                    | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | PATCH /open-banking/automatic-payments/v2/pix/recurring-payments/{recurringPaymentId}​ | Pix - Cancelar iniciação de pagamento​​                                                                                        | Será necessário o reporte porém temos que aguardar a <br> definição do nome do campo pelo GT Especificações Serviços​                      | -
+              
+                  <br>
+                type: string
+              revocationReasonDetail:
+                description: |
+                  Detalhe sobre o motivo de revogação indicado no campo
+                  1. Envio obrigatório para a role Server e Client
+
+                  | Endpoint  | Descrição Jornada | Obrigatoriedade Client  | Obrigatoriedade Server  |
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | POST /automatic-payments/v1/recurring-consents                  | Criar consentimento para iniciação de pagamento​                                                                              | -                                    | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | GET /automatic-payments/v1/recurring-consents/{consentId}​       | Consultar consentimento para iniciação de pagamento​​                                                                          | Se revogation: {RevocationReasonCode, RevocationReasonDetail, RevokedBy, RevokedFrom}​ <br> Se rejected: {RejectedBy, RejectedFrom}​        | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | PATCH /automatic-payments/v1/recurring-consents/{consentId}​     | Rejeita, revoga ou edita um consentimento​          ​                                                                          | Se revogation: {RevocationReasonCode, RevocationReasonDetail, RevokedBy, RevokedFrom}​ <br> Se rejected: {RejectedBy, RejectedFrom}​        | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |        
+                  | POST /automatic-payments/v1/pix/recurring-payments​​              | Pix - Criar iniciação de pagamento limitada por parametrização de tempo ou limite total realizada no consentimento​​           | -                                  
+                  | --------- | ----------------- | ----------------------- | ----------------------- |        
+                  | GET /automatic-payments/v1/pix/recurring-payments?consentId=​    | Pix – Consulta informações de transações de pagamentos associadas a um consentimento​                                         | -                                
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | GET /automatic-payments/v1/pix/recurring-payments/{paymentId}​   | Pix - Consultar iniciação de pagamento​                                                                                       | -                                    | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | PATCH /automatic-payments/v1/pix/recurring-payments/{paymentId}​ | Pix - Cancelar iniciação de pagamento​​                                                                                        | Será necessário o reporte porém temos que aguardar a <br> definição do nome do campo pelo GT Especificações Serviços​                      | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | POST /open-banking/automatic-payments/v2/recurring-consents     | Criar consentimento para iniciação de pagamento​                                                                              | -                                    | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | GET /open-banking/automatic-payments/v2/recurring-consents/{recurringConsentId}​       | Consultar consentimento para iniciação de pagamento​​                                                                          | Se revogation: {RevocationReasonCode, RevocationReasonDetail, RevokedBy, RevokedFrom}​ <br> Se rejected: {RejectedBy, RejectedFrom}​        | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | PATCH /open-banking/automatic-payments/v2/recurring-consents/{recurringConsentId}​     | Rejeita, revoga ou edita um consentimento​          ​                                                                          | Se revogation: {RevocationReasonCode, RevocationReasonDetail, RevokedBy, RevokedFrom}​ <br> Se rejected: {RejectedBy, RejectedFrom}​        | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |        
+                  | POST /open-banking/automatic-payments/v2/pix/recurring-payments​​              | Pix - Criar iniciação de pagamento limitada por parametrização de tempo ou limite total realizada no consentimento​​           | -                                  
+                  | --------- | ----------------- | ----------------------- | ----------------------- |        
+                  | GET /open-banking/automatic-payments/v2/pix/recurring-payments/{recurringPaymentId}​   | Pix - Consultar iniciação de pagamento​                                                                                       | -                                    | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | PATCH /open-banking/automatic-payments/v2/pix/recurring-payments/{recurringPaymentId}​ | Pix - Cancelar iniciação de pagamento​​                                                                                        | Será necessário o reporte porém temos que aguardar a <br> definição do nome do campo pelo GT Especificações Serviços​                      | -
+              
+                  <br>
+                type: string
+              revokedBy:
+                description: |
+                  Quem iniciou a solicitação de revogação 
+                  1. Envio obrigatório para a role Server e Client
+
+                  | Endpoint  | Descrição Jornada | Obrigatoriedade Client  | Obrigatoriedade Server  |
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | POST /automatic-payments/v1/recurring-consents                  | Criar consentimento para iniciação de pagamento​                                                                              | -                                    | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | GET /automatic-payments/v1/recurring-consents/{consentId}​       | Consultar consentimento para iniciação de pagamento​​                                                                          | Se revogation: {RevocationReasonCode, RevocationReasonDetail, RevokedBy, RevokedFrom}​ <br> Se rejected: {RejectedBy, RejectedFrom}​        | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | PATCH /automatic-payments/v1/recurring-consents/{consentId}​     | Rejeita, revoga ou edita um consentimento​          ​                                                                          | Se revogation: {RevocationReasonCode, RevocationReasonDetail, RevokedBy, RevokedFrom}​ <br> Se rejected: {RejectedBy, RejectedFrom}​        | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |        
+                  | POST /automatic-payments/v1/pix/recurring-payments​​              | Pix - Criar iniciação de pagamento limitada por parametrização de tempo ou limite total realizada no consentimento​​           | -                                  
+                  | --------- | ----------------- | ----------------------- | ----------------------- |        
+                  | GET /automatic-payments/v1/pix/recurring-payments?consentId=​    | Pix – Consulta informações de transações de pagamentos associadas a um consentimento​                                         | -                                
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | GET /automatic-payments/v1/pix/recurring-payments/{paymentId}​   | Pix - Consultar iniciação de pagamento​                                                                                       | -                                    | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | PATCH /automatic-payments/v1/pix/recurring-payments/{paymentId}​ | Pix - Cancelar iniciação de pagamento​​                                                                                        | Será necessário o reporte porém temos que aguardar a <br> definição do nome do campo pelo GT Especificações Serviços​                      | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | POST /open-banking/automatic-payments/v2/recurring-consents     | Criar consentimento para iniciação de pagamento​                                                                              | -                                    | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | GET /open-banking/automatic-payments/v2/recurring-consents/{recurringConsentId}​       | Consultar consentimento para iniciação de pagamento​​                                                                          | Se revogation: {RevocationReasonCode, RevocationReasonDetail, RevokedBy, RevokedFrom}​ <br> Se rejected: {RejectedBy, RejectedFrom}​        | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | PATCH /open-banking/automatic-payments/v2/recurring-consents/{recurringConsentId}​     | Rejeita, revoga ou edita um consentimento​          ​                                                                          | Se revogation: {RevocationReasonCode, RevocationReasonDetail, RevokedBy, RevokedFrom}​ <br> Se rejected: {RejectedBy, RejectedFrom}​        | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |        
+                  | POST /open-banking/automatic-payments/v2/pix/recurring-payments​​              | Pix - Criar iniciação de pagamento limitada por parametrização de tempo ou limite total realizada no consentimento​​           | -                                  
+                  | --------- | ----------------- | ----------------------- | ----------------------- |        
+                  | GET /open-banking/automatic-payments/v2/pix/recurring-payments/{recurringPaymentId}​   | Pix - Consultar iniciação de pagamento​                                                                                       | -                                    | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | PATCH /open-banking/automatic-payments/v2/pix/recurring-payments/{recurringPaymentId}​ | Pix - Cancelar iniciação de pagamento​​                                                                                        | Será necessário o reporte porém temos que aguardar a <br> definição do nome do campo pelo GT Especificações Serviços​                      | -
+              
+                  <br>
+                type: string
+                enum:
+                  - INICIADORA: apenas para a role CLient
+                  - USUARIO: para a role Server e Client
+                  - DETENTORA: apenas para a role Server
+              revokedFrom:
+                description: |
+                  Canal onde iniciou-se o processo de revogação
+                  1. Envio obrigatório para a role Server e Client
+
+                  | Endpoint  | Descrição Jornada | Obrigatoriedade Client  | Obrigatoriedade Server  |
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | POST /automatic-payments/v1/recurring-consents                  | Criar consentimento para iniciação de pagamento​                                                                              | -                                    | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | GET /automatic-payments/v1/recurring-consents/{consentId}​       | Consultar consentimento para iniciação de pagamento​​                                                                          | Se revogation: {RevocationReasonCode, RevocationReasonDetail, RevokedBy, RevokedFrom}​ <br> Se rejected: {RejectedBy, RejectedFrom}​        | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | PATCH /automatic-payments/v1/recurring-consents/{consentId}​     | Rejeita, revoga ou edita um consentimento​          ​                                                                          | Se revogation: {RevocationReasonCode, RevocationReasonDetail, RevokedBy, RevokedFrom}​ <br> Se rejected: {RejectedBy, RejectedFrom}​        | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |        
+                  | POST /automatic-payments/v1/pix/recurring-payments​​              | Pix - Criar iniciação de pagamento limitada por parametrização de tempo ou limite total realizada no consentimento​​           | -                                  
+                  | --------- | ----------------- | ----------------------- | ----------------------- |        
+                  | GET /automatic-payments/v1/pix/recurring-payments?consentId=​    | Pix – Consulta informações de transações de pagamentos associadas a um consentimento​                                         | -                                
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | GET /automatic-payments/v1/pix/recurring-payments/{paymentId}​   | Pix - Consultar iniciação de pagamento​                                                                                       | -                                    | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | PATCH /automatic-payments/v1/pix/recurring-payments/{paymentId}​ | Pix - Cancelar iniciação de pagamento​​                                                                                        | Será necessário o reporte porém temos que aguardar a <br> definição do nome do campo pelo GT Especificações Serviços​                      | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | POST /open-banking/automatic-payments/v2/recurring-consents     | Criar consentimento para iniciação de pagamento​                                                                              | -                                    | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | GET /open-banking/automatic-payments/v2/recurring-consents/{recurringConsentId}​       | Consultar consentimento para iniciação de pagamento​​                                                                          | Se revogation: {RevocationReasonCode, RevocationReasonDetail, RevokedBy, RevokedFrom}​ <br> Se rejected: {RejectedBy, RejectedFrom}​        | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | PATCH /open-banking/automatic-payments/v2/recurring-consents/{recurringConsentId}​     | Rejeita, revoga ou edita um consentimento​          ​                                                                          | Se revogation: {RevocationReasonCode, RevocationReasonDetail, RevokedBy, RevokedFrom}​ <br> Se rejected: {RejectedBy, RejectedFrom}​        | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |        
+                  | POST /open-banking/automatic-payments/v2/pix/recurring-payments​​              | Pix - Criar iniciação de pagamento limitada por parametrização de tempo ou limite total realizada no consentimento​​           | -                                  
+                  | --------- | ----------------- | ----------------------- | ----------------------- |        
+                  | GET /open-banking/automatic-payments/v2/pix/recurring-payments/{recurringPaymentId}​   | Pix - Consultar iniciação de pagamento​                                                                                       | -                                    | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | PATCH /open-banking/automatic-payments/v2/pix/recurring-payments/{recurringPaymentId}​ | Pix - Cancelar iniciação de pagamento​​                                                                                        | Será necessário o reporte porém temos que aguardar a <br> definição do nome do campo pelo GT Especificações Serviços​                      | -
+              
+                  <br>
+                type: string
+                enum:
+                  - INICIADORA: para a role Server e Client
+                  - DETENTORA: apenas para a role Server
+              rejectedBy:
+                description: |
+                  Quem iniciou a solicitação de rejeição
+                  1. Envio obrigatório para a role Server e Client
+
+                  | Endpoint  | Descrição Jornada | Obrigatoriedade Client  | Obrigatoriedade Server  |
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | POST /automatic-payments/v1/recurring-consents                  | Criar consentimento para iniciação de pagamento​                                                                              | -                                    | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | GET /automatic-payments/v1/recurring-consents/{consentId}​       | Consultar consentimento para iniciação de pagamento​​                                                                          | Se revogation: {RevocationReasonCode, RevocationReasonDetail, RevokedBy, RevokedFrom}​ <br> Se rejected: {RejectedBy, RejectedFrom}​        | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | PATCH /automatic-payments/v1/recurring-consents/{consentId}​     | Rejeita, revoga ou edita um consentimento​          ​                                                                          | Se revogation: {RevocationReasonCode, RevocationReasonDetail, RevokedBy, RevokedFrom}​ <br> Se rejected: {RejectedBy, RejectedFrom}​        | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |        
+                  | POST /automatic-payments/v1/pix/recurring-payments​​              | Pix - Criar iniciação de pagamento limitada por parametrização de tempo ou limite total realizada no consentimento​​           | -                                  
+                  | --------- | ----------------- | ----------------------- | ----------------------- |        
+                  | GET /automatic-payments/v1/pix/recurring-payments?consentId=​    | Pix – Consulta informações de transações de pagamentos associadas a um consentimento​                                         | -                                
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | GET /automatic-payments/v1/pix/recurring-payments/{paymentId}​   | Pix - Consultar iniciação de pagamento​                                                                                       | -                                    | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | PATCH /automatic-payments/v1/pix/recurring-payments/{paymentId}​ | Pix - Cancelar iniciação de pagamento​​                                                                                        | Será necessário o reporte porém temos que aguardar a <br> definição do nome do campo pelo GT Especificações Serviços​                      | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | POST /open-banking/automatic-payments/v2/recurring-consents     | Criar consentimento para iniciação de pagamento​                                                                              | -                                    | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | GET /open-banking/automatic-payments/v2/recurring-consents/{recurringConsentId}​       | Consultar consentimento para iniciação de pagamento​​                                                                          | Se revogation: {RevocationReasonCode, RevocationReasonDetail, RevokedBy, RevokedFrom}​ <br> Se rejected: {RejectedBy, RejectedFrom}​        | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | PATCH /open-banking/automatic-payments/v2/recurring-consents/{recurringConsentId}​     | Rejeita, revoga ou edita um consentimento​          ​                                                                          | Se revogation: {RevocationReasonCode, RevocationReasonDetail, RevokedBy, RevokedFrom}​ <br> Se rejected: {RejectedBy, RejectedFrom}​        | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |        
+                  | POST /open-banking/automatic-payments/v2/pix/recurring-payments​​              | Pix - Criar iniciação de pagamento limitada por parametrização de tempo ou limite total realizada no consentimento​​           | -                                  
+                  | --------- | ----------------- | ----------------------- | ----------------------- |        
+                  | GET /open-banking/automatic-payments/v2/pix/recurring-payments/{recurringPaymentId}​   | Pix - Consultar iniciação de pagamento​                                                                                       | -                                    | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | PATCH /open-banking/automatic-payments/v2/pix/recurring-payments/{recurringPaymentId}​ | Pix - Cancelar iniciação de pagamento​​                                                                                        | Será necessário o reporte porém temos que aguardar a <br> definição do nome do campo pelo GT Especificações Serviços​                      | -
+              
+                  <br>
+                type: string
+                enum:
+                  - INICIADORA: apenas para a role Client
+                  - USUARIO: para a role Server e Client
+                  - DETENTORA: apenas para a role Server
+              rejectedFrom:
+                description: |
+                  Canal onde iniciou-se o processo de rejeição
+                  1. Envio obrigatório para a role Server e Client
+
+                  | Endpoint  | Descrição Jornada | Obrigatoriedade Client  | Obrigatoriedade Server  |
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | POST /automatic-payments/v1/recurring-consents                  | Criar consentimento para iniciação de pagamento​                                                                              | -                                    | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | GET /automatic-payments/v1/recurring-consents/{consentId}​       | Consultar consentimento para iniciação de pagamento​​                                                                          | Se revogation: {RevocationReasonCode, RevocationReasonDetail, RevokedBy, RevokedFrom}​ <br> Se rejected: {RejectedBy, RejectedFrom}​        | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | PATCH /automatic-payments/v1/recurring-consents/{consentId}​     | Rejeita, revoga ou edita um consentimento​          ​                                                                          | Se revogation: {RevocationReasonCode, RevocationReasonDetail, RevokedBy, RevokedFrom}​ <br> Se rejected: {RejectedBy, RejectedFrom}​        | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |        
+                  | POST /automatic-payments/v1/pix/recurring-payments​​              | Pix - Criar iniciação de pagamento limitada por parametrização de tempo ou limite total realizada no consentimento​​           | -                                  
+                  | --------- | ----------------- | ----------------------- | ----------------------- |        
+                  | GET /automatic-payments/v1/pix/recurring-payments?consentId=​    | Pix – Consulta informações de transações de pagamentos associadas a um consentimento​                                         | -                                
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | GET /automatic-payments/v1/pix/recurring-payments/{paymentId}​   | Pix - Consultar iniciação de pagamento​                                                                                       | -                                    | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | PATCH /automatic-payments/v1/pix/recurring-payments/{paymentId}​ | Pix - Cancelar iniciação de pagamento​​                                                                                        | Será necessário o reporte porém temos que aguardar a <br> definição do nome do campo pelo GT Especificações Serviços​                      | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | POST /open-banking/automatic-payments/v2/recurring-consents     | Criar consentimento para iniciação de pagamento​                                                                              | -                                    | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | GET /open-banking/automatic-payments/v2/recurring-consents/{recurringConsentId}​       | Consultar consentimento para iniciação de pagamento​​                                                                          | Se revogation: {RevocationReasonCode, RevocationReasonDetail, RevokedBy, RevokedFrom}​ <br> Se rejected: {RejectedBy, RejectedFrom}​        | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | PATCH /open-banking/automatic-payments/v2/recurring-consents/{recurringConsentId}​     | Rejeita, revoga ou edita um consentimento​          ​                                                                          | Se revogation: {RevocationReasonCode, RevocationReasonDetail, RevokedBy, RevokedFrom}​ <br> Se rejected: {RejectedBy, RejectedFrom}​        | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |        
+                  | POST /open-banking/automatic-payments/v2/pix/recurring-payments​​              | Pix - Criar iniciação de pagamento limitada por parametrização de tempo ou limite total realizada no consentimento​​           | -                                  
+                  | --------- | ----------------- | ----------------------- | ----------------------- |        
+                  | GET /open-banking/automatic-payments/v2/pix/recurring-payments/{recurringPaymentId}​   | Pix - Consultar iniciação de pagamento​                                                                                       | -                                    | -
+                  | --------- | ----------------- | ----------------------- | ----------------------- |
+                  | PATCH /open-banking/automatic-payments/v2/pix/recurring-payments/{recurringPaymentId}​ | Pix - Cancelar iniciação de pagamento​​                                                                                        | Será necessário o reporte porém temos que aguardar a <br> definição do nome do campo pelo GT Especificações Serviços​                      | -
+                  <br>
+                type: string
+                enum:
+                  - INICIADORA: para a role Server e Client
+                  - DETENTORA: apenas para a role Server
+              grantType:
+                description: |
+                  O valor deste campo deve ser o valor enviado no campo grant_type da chamada ao endpoint de token
+                  
+                    `AUTHORIZATION_CODE`: Utilizado na autorização de acesso a um recurso por meio de login de usuário
+                  
+                    `REFRESH_TOKEN`: Utilizado para obter um novo token de acesso quando o token anterior expira
+                  
+                    `CLIENT_CREDENTIALS`: Utilizado na autorização de acesso entre aplicações onde não há a figura do usuário
+                type: string
+                enum:
+                  - AUTHORIZATION_CODE
+                  - REFRESH_TOKEN
+                  - CLIENT_CREDENTIALS
+              cancelledFrom:
+                description: |
+                  Identifica origem da rejeição ou revogação de um vínculo de dispositivo.
+                type: string
+                enum:
+                  - INICIADORA
+                  - DETENTORA
+              amountType:
+                description: |
+                  Valida se o serviço contratado possui maior conversão em relação ao tipo do valor definido, sendo ele fixo ou variável​.
+                type: string
+                enum:
+                  - FIXO
+                  - VARIAVEL
+              interval:
+                description: |
+                  Periodicidade que a recorrência foi definida (semanal, trimestral, anual...)​.
+
+                  Regras:
+                    - Preencher com o valor do campo "interval"​
+                type: string
+              isFirstPayment:
+                description: |
+                  Valida se o serviço possui um pagamento associado na adesão.
+                type: string
+                enum:
+                  - "TRUE"
+                  - "FALSE"
+              hasMinimumAmount:
+                description: |
+                  Valida se possui o valor mínimo definido pelo usuário recebedor​.
+                type: string
+                enum:
+                  - "TRUE"
+                  - "FALSE"
+              isRetryAccepted:
+                description: |
+                  Identifica se foi autorizado a tentativas de pagamento em dias subsequentes na situação de falha do pagamento da recorrência
+                  
+                  Regras:
+                    - Preencher com o valor do campo "isRetryAccepted"​
+                type: string
+              recurringPaymentId:
+                description: |
+                  Contagem de acionamentos feitos no pagamento
+
+                  Regras:
+                    - Para Pagamentos v4: Preencher com o valor do campo "/data/paymentId"
+                    - Para Pagamentos Automáticos v2: Preencher com o valor do campo "/data/recurringPaymentId"​
+                type: string
+              originalRecurringPaymentId:
+                description: |
+                  Identifica o primeiro pagamento da recorrência em relação as retentativas​.
+
+                  Regras:
+                    - Preencher com o valor do campo "originalRecurringPaymentId"​
+                type: string
+              paymentReference:
+                description: |
+                  Identifica a referência do pagamento no tempo (semanal, mensal, trimestral...).
+                  
+                  Regras:​
+                    - Preencher com o valor do campo "paymentReference"
+                type: string
+              cancellationReason: 
+                description: |
+                  Identifica o estado que o pagamento estava quando foi cancelado​.
+
+                  Regras:
+                    - Preencher com o valor do campo "cancellation.reason"
+                type: string
+              nfcPayment:
+                description: |
+                  Indica se o pagamento foi realizado via NFC.
+                  
+                  Regras:
+                    - Preencher com o valor do campo "nfcPayment"
+                type: string
+                enum:
+                  - "TRUE"
+                  - "FALSE"
+              
+          timestamp:
+            description: Data/Hora UTC no formato ISO8601 com milissegundos (YYYY-MM-DDTHH:mm:ss.sssZ) do momento em que a chamada foi disparada, imediatamente antes do primeiro byte enviado na requisição.
+            type: string
+            format: date-time
+            maxLength: 28
+            example: "2021-11-11T18:08:08.278Z"
+          processTimespan:
+            description: Tempo em milissegundos inteiros decorrido desde o registro do timestamp até a chegada do primeiro byte da resposta do server.
+            type: integer
+            format: int16
+            example: 120
+          clientSSId:
+            description: Identificador do software statement de onde a chamada foi disparada. A PCM garante que foi esta orgId que obteve o token de acesso utilizado neste reporte.
+            type: string
+            format: uuid
+            maxLength: 36
+            pattern: "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+            example: "84570da9-567b-4201-9b77-c715bc5bffde"
+          clientOrgId:
+            description: Identificador da organização **de onde** a chamada foi disparada
+            allOf:
+              - $ref: "#/components/schemas/UUID"
+          serverOrgId:
+            description: Identificador da organização **para onde** a chamada foi feita
+            type: string
+            format: uuid
+            maxLength: 36
+            pattern: "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+            example: "c1ca8e62-9d6f-4ea3-84f2-d66bc0a8f7dc"
+          endpointUriPrefix:
+            description: |
+              Endereço do servidor de destino da chamada, incluindo o prefixo quando houver. O formato do campo deverá ser o seguinte: `https://{host}/{prefixo}`, sendo:
+
+              * `host`: endereço FQDN do servidor de destino
+              * `prefixo`: toda a parte do path que vem antes da string `/open-banking`
+
+              Exemplos:
+
+              1. Para uma requisição em `https://openbanking.instituicao-1.com.br/opbk/open-banking/products-services/v1/business-accounts`, o dado a ser enviado é `https://openbanking.instituicao-1.com.br/opbk`.
+              1. Para uma requisição em `https://openbanking.instituicao-2.com.br/open-banking/products-services/v1/business-accounts`, o dado a ser enviado é `https://openbanking.instituicao-1.com.br/`.
+
+              Nos reportes relativos aos endpoints /token e /register este campo deverá conter a URL inteira do request. 
+
+              Exemplos: `https://oauth2.cartaodummy.opf.instituicao/as/token.oauth2` `https://instituicao.com.br/orgs/instituicao/reg`
+            type: string
+            pattern: ^[- /:_.',0-9a-zA-Z]{0,200}$
+            maxLength: 200
+            example: https://openbanking.instituicao-1.com.br/opbk
+          role:
+            description: ENUM indicando se o reporte que está sendo enviado apresenta a visão do server ou do client. Obrigatório valor "CLIENT"
+            type: string
+            enum:
+              - CLIENT
+              - SERVER
+
+    ServerReportRequest:
+      description: Representa os dados que deverão ser enviados para a inclusão de reportes pelo lado do Server (receptor da chamada). Informações adicionais sobre cada campo podem ser encontradas na documentação funcional em [https://openfinancebrasil.atlassian.net/wiki/spaces/OF/pages/37879861/Reporte#Modelos-para-reportes-Private](https://openfinancebrasil.atlassian.net/wiki/spaces/OF/pages/37879861/Reporte#Modelos-para-reportes-Private)
+      type: array
+      minItems: 1
+      maxItems: 5000
+      items:
+        type: object
+        required:
+          - fapiInteractionId
+          - endpoint
+          - statusCode
+          - httpMethod
+          - timestamp
+          - processTimespan
+          - clientOrgId
+          - serverOrgId
+          - role
+        properties:
+          fapiInteractionId:
+            description: UUID que identifica uma transação específica entre dois participantes. Esse dado pode ser encontrado no header x-fapi-interaction-id que é informado pelo Client e devolvido pelo Server. Mais informações em [Cabeçalhos HTTP](https://openbanking-brasil.github.io/areadesenvolvedor/#cabecalhos-http) na documentação do Open Finance Brasil.
+            type: string
+            format: uuid
+            maxLength: 36
+            pattern: "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+            example: "d78fc4e5-37ca-4da3-adf2-9b082bf92280"
+          endpoint:
+            $ref: "#/components/schemas/PrivateReportEndpoints"
+          statusCode:
+            description: Status de retorno HTTP da solicitação. No caso de ocorrer um timeout client side preencher com um código 408 [conforme documentação](https://openfinancebrasil.atlassian.net/wiki/spaces/OF/pages/37879861/Reporte)
+            type: integer
+            format: int32
+            example: 200
+            minimum: 200
+            maximum: 599
+          httpMethod:
+            description: Método HTTP da solicitação.
+            type: string
+            enum: ["GET", "POST", "PUT", "DELETE", "PATCH"]
+            example: GET
+          correlationId:
+            description: Não utilizado pelo server.
+            type: string
+            pattern: ^[- /:_.',0-9a-zA-Z]{0,100}$
+            maxLength: 100
+            example: "uGQHwNupARo7I9E2PLJZph18a0M9y7DcUe7ITt3DqUOJd9NVjnskxf2"
+          timestamp:
+            description: Data/Hora UTC no formato ISO8601 com milissegundos (YYYY-MM-DDTHH:mm:ss.sssZ) do momento em que a chamada foi recebida, imediatamente antes do primeiro byte enviado na requisição.
+            type: string
+            format: date-time
+            maxLength: 28
+            example: "2021-11-11T18:08:08.152Z"
+          processTimespan:
+            description: Tempo em milissegundos inteiros decorrido desde o registro do timestamp até a finalização do envio dos dados.
+            type: integer
+            format: int16
+            example: 120
+          clientOrgId:
+            description: Identificador da organização **de onde** a chamada foi disparada
+            allOf:
+              - $ref: "#/components/schemas/UUID"
+          serverOrgId:
+            description: Identificador da organização **para onde** a chamada foi feita. A PCM garante que foi esta orgId que obteve o token de acesso utilizado neste reporte.
+            type: string
+            format: uuid
+            maxLength: 36
+            pattern: "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+            example: "c1ca8e62-9d6f-4ea3-84f2-d66bc0a8f7dc"
+          additionalInfo:
+            description: Informações adicionais sobre o reporte deste endpoint/método. Possui característica variável. As regras de preenchimento estão na documentação funcional em [openfinancebrasil](https://openfinancebrasil.atlassian.net/wiki/spaces/OF/pages/806158355/Planilha+AdditionalInfo). Atenção especial na tabela Excel com a listagem de endpoints em [https://openfinancebrasil.atlassian.net/wiki/spaces/OF/pages/806158355/Planilha+AdditionalInfo](https://openfinancebrasil.atlassian.net/wiki/spaces/OF/pages/806158355/Planilha+AdditionalInfo)
+            type: object
+            properties:
+              dropReason:
+                description: |
+                  Regras:
+                    - O campo dropReason deve ser adicionado nas informações do campo additionalInfo que deverá ser enviado no reporte do provedor do serviço consumido (papel SERVER) 
+                    - O reporte deverá ser feito por todos os transmissores de dados e detentoras de conta. Para os casos em que ocorram falhas técnicas que impossibilitem a verificação do CPF/CNPJ (incluindo, mas não se limitando, a erros HTTP 4xx, 500 ou timeout na resposta), o reporte deve ser realizado com o valor NO_CREDENTIAL, Em jornadas de múltipla alçada de pessoas jurídicas, quando a autenticação é bem-sucedida mas os poderes constituídos são insuficientes para finalização do Hybrid Flow, deve-se usar NO_AUTHORITY.
+                  
+                  Diretrizes:
+                  
+                    - `NONE`: quando o CPF (loggedUser) / CNPJ (businessEntity) possui credencial autenticadora e poderes suficientes para prosseguir o fluxo monitorado - exemplo: PF, cliente, que possui credencial ativa, mas não se autenticou; cliente que se autenticou utilizando a credencial correta. 
+                    - `NO_CREDENTIAL`: quando o CPF (loggedUser) / CNPJ (businessEntity) não for cliente ou não possuir credencial válida/ativa para prosseguir no fluxo monitorado ou quando o HTTP response code for diferente de 201.
+                    - `NO_AUTHORITY`: quando o CPF (loggedUser) / CNPJ (businessEntity) consegue se autenticar, mas não dispõe de poderes ou alçadas para prosseguir no fluxo de compartilhamento de dados e serviços. 
+                    - `NO_AUTHORITY_PERSON_MISMATCH`: quando o CPF (loggedUser) não possui relação com a credencial utilizada na etapa de autenticação do Hybrid Flow - exemplo: consentimento criado para um CPF e autenticado por outro; criado para um CNPJ e autenticado por CPF sem relação com o CNPJ. 
+                type: string
+          role:
+            description: ENUM indicando se o reporte que está sendo enviado apresenta a visão do server ou do client. Obrigatório valor "SERVER"
+            type: string
+            enum:
+              - CLIENT
+              - SERVER
+
+    OpendataReportRequest:
+      description: Modelo que representa os dados a serem enviados às APIs de dados abertos. Informações adicionais sobre cada campo podem ser encontradas na documentação funcional em [https://openfinancebrasil.atlassian.net/wiki/spaces/OF/pages/37879861/Reporte#Reportes-OpenData](https://openfinancebrasil.atlassian.net/wiki/spaces/OF/pages/37879861/Reporte#Reportes-OpenData).
+      additionalProperties: false
+      type: array
+      minItems: 1
+      maxItems: 5000
+      items:
+        type: object
+        required:
+          - endpoint
+          - statusCode
+          - httpMethod
+          - timestamp
+          - processTimespan
+          - additionalInfo
+        properties:
+          endpoint:
+            $ref: "#/components/schemas/OpendataReportEndpoints"
+          statusCode:
+            description: Status de retorno HTTP da solicitação.
+            type: integer
+            format: int32
+            example: 200
+            minimum: 200
+            maximum: 599
+          httpMethod:
+            description: Método HTTP da solicitação.
+            type: string
+            enum: ["GET"]
+            example: GET
+          timestamp:
+            description: Data/Hora UTC no formato ISO8601 com milissegundos (YYYY-MM-DDTHH:mm:ss.sssZ) do momento em que a chamada foi recebida.
+            type: string
+            format: date-time
+            maxLength: 28
+            example: "2021-11-11T18:08:08.421Z"
+          processTimespan:
+            description: Tempo em milissegundos inteiros decorrido desde o recebimento do request até o momento imediatamente anterior ao envio do primeiro byte da resposta.
+            type: integer
+            format: int16
+            example: 120
+          additionalInfo:
+            $ref: "#/components/schemas/OpendataAdditionalInfo"
+
+    ReportResponse:
+      description: Representa os dados que serão retornados pelas operações de inclusão de reportes.
+      additionalProperties: false
+      required:
+        - reportId
+        - status
+      type: object
+      properties:
+        reportId:
+          description: Identificador único interno do reporte no formato UUID v4.
+          type: string
+          format: uuid
+          maxLength: 36
+          pattern: "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+          example: "9a97c2df-b261-4fc2-aa66-d1b5168397da"
+        status:
+          $ref: "#/components/schemas/ReportStatus"
+        correlationId:
+          description: Retorna o valor do atributo `correlationId` informado na solicitação de inclusão de reporte sem alteração.
+          type: string
+          pattern: ^[- /:_.',0-9a-zA-Z]{0,100}$
+          maxLength: 100
+          example: "xxuGQHwNupARo7I9E2PLJZph18a0M9y7DcUe7ITt3DqUOJd9NVjnskxf2"
+        message:
+          description: Caso a solicitação contenha algum problema em seu formato, ou caso haja algum tipo de falha detectável no momento da requisição, esse campo trará detalhes sobre o erro ocorrido. Informações adicionais sobre os tipos de erros podem ser encontradas em [https://openfinancebrasil.atlassian.net/wiki/spaces/OF/pages/46170119/Troubleshooting+-+PCM](https://openfinancebrasil.atlassian.net/wiki/spaces/OF/pages/46170119/Troubleshooting+-+PCM)
+          type: string
+          pattern: ^[- /:_.',0-9a-zA-Z]{0,200}$
+          maxLength: 200
+          example: "Missing fields: 'fapiInteractionId', 'endpoint'"
+
+    HybridFlowReportResponse:
+      description: Representa os dados que serão retornados pelas operações de inclusão de reportes.
+      additionalProperties: false
+      required:
+        - reportId
+      type: array
+      items:
+        type: object
+        properties:
+          reportId:
+            description: Identificador único interno do reporte no formato UUID v4.
+            type: string
+            format: uuid
+            maxLength: 36
+            pattern: "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+            example: "9a97c2df-b261-4fc2-aa66-d1b5168397da"
+
+    ReportStatus:
+      description: |
+        Informa o status do registro de reporte.
+        * **DISCARDED**: O status `DISCARDED` indica que o reporte enviado pelo participante foi rejeitado pela PCM. O motivo do descarte será enviado com a resposta, podendo ser por conta de um reporte inválido ou por um erro no processamento. Não é possível modificar um reporte `DISCARDED`, portanto o reportador deverá corrigir o registro que apresentou erro e reenviar via POST.
+        * **SINGLE**: O status `SINGLE` indica que o reporte em questão não tem uma contraparte. Ele é utilizado em casos onde a conciliação entre dois reportes não é possível.
+        * **ACCEPTED**: O status `ACCEPTED` indica que a validação de formato do reporte não tem erros e este será enviado para processamento.
+        * **UNPAIRED**: O status `UNPAIRED` significa que o reporte atual não possui uma correspondência em outro reporte através do atributo `fapiInteractionId`. Indica um reporte _divergente_.
+        * **PAIRED_INCONSISTENT**: O status `PAIRED_INCONSISTENT` significa que o reporte corrente possui uma contraparte com o mesmo `fapiInteractionId`, mas os demais dados estão inconsistentes. Indica um reporte _divergente_.
+        * **PAIRED**: Indica que o reporte tem uma contraparte com o mesmo `fapiInteractionId` e os demais dados estão conciliados. Representa o estado final desejado em um fluxo correto.
+      type: string
+      enum:
+        - DISCARDED
+        - SINGLE
+        - ACCEPTED
+        - UNPAIRED
+        - PAIRED_INCONSISTENT
+        - PAIRED
+
+    CreditPortabilityStatus:
+      description: |
+        Informação sobre o status de um pedido de portabilidade de crédito, onde:
+        - `RECEIVED`: Estado inicial. Indica que o pedido de portabilidade foi solicitado junto à instituição credora. O pedido deve permanecer neste estado até o próximo dia útil (D+1) onde começará a contar o prazo de 3 dias úteis para a etapa de contraproposta e o pedido de portabilidade deverá ser movido para PENDING 
+        - `PENDING`: Indica que o pedido de portabilidade de crédito está na fase de contraproposta, onde a instituição credora poderá enviar uma contraproposta ou não para o cliente por qualquer canal (email, telefone, etc.) porém o aceite só deverá ser valido se o cliente aprovar no canal digital da instituição credora
+        - `ACCEPTED_SETTLEMENT_IN_PROCESS`: Indica que a contraproposta não foi aceita pelo cliente e a instituição proponente terá que quitar o valor do contrato no mesmo dia em que o estado foi ativado.
+        - `ACCEPTED_SETTLEMENT_COMPLETED`: Indica que a instituição proponente já liquidou o contrato e comunicou a respeito à credora que está validando os dados do contrato bem como valores recebidos para a quitação do mesmo (nesta etapa a instituição credora tem 2 dias úteis para fornecer a confirmação e o recibo de quitação do contrato de empréstimo)
+        - `PORTABILITY_COMPLETED`: Indica que o pedido de portabilidade foi concluído com sucesso REJECTED: Indica que o pedido de portabilidade de crédito foi rejeitado, seja porque o cliente aceitou a contraproposta, ou porque a proponente rejeitou a liquidação que excedeu em 15% o valor do contrato original, entre outras possibilidades
+        - `CANCELLED`: Indica que o cliente cancelou o pedido de portabilidade de crédito 
+        - `PAYMENT_ISSUE`: Indica que a Instituição Credora encontrou alguma inconsistência na liquidação efetuada e que a Instituição Proponente deverá realizar ajustes conforme sugerido pela Instituição Credora para solucionar a pendência antes do cancelamento do pedido de portabilidade de crédito
+      type: string
+      enum:
+        - PENDING 
+        - RECEIVED 
+        - ACCEPTED_SETTLEMENT_IN_PROCESS
+        - ACCEPTED_SETTLEMENT_COMPLETED
+        - PORTABILITY_COMPLETED
+        - REJECTED
+        - CANCELLED
+
+    ReportModel:
+      description: Representa um reporte devidamente persistido.
+      allOf:
+        - $ref: "#/components/schemas/ClientReportRequest"
+        - type: object
+          properties:
+            reportId:
+              description: |
+                Identificador único do registro criado na Plataforma de Coleta de Métricas.
+              type: string
+              format: uuid
+              maxLength: 36
+              pattern: "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+            pairedReportId:
+              description: |
+                Esse atributo indica o `reportId` do registro que forma uma correlação com o presente registro. Se essa informação existir, o status do registro atual deverá ser _PAIRED_
+              type: string
+              format: uuid
+              maxLength: 36
+              pattern: "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+            status:
+              $ref: "#/components/schemas/ReportStatus"
+            createdAt:
+              description: |
+                Carimbo do tempo do momento da criação do registro
+              type: string
+              format: date-time
+              maxLength: 28
+            updatedAt:
+              description: |
+                Carimbo do tempo do momento da última atualização do registro
+              type: string
+              format: date-time
+              maxLength: 28
+
+    OpendataReportModel:
+      description: Representa um reporte devidamente persistido.
+      allOf:
+        - $ref: "#/components/schemas/OpendataReportRequest"
+        - type: object
+          properties:
+            reportId:
+              description: |
+                Identificador único do registro criado na Plataforma de Coleta de Métricas.
+              type: string
+              format: uuid
+              maxLength: 36
+              pattern: "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+            createdAt:
+              description: |
+                Carimbo do tempo do momento da criação do registro
+              type: string
+              format: date-time
+              maxLength: 28
+            updatedAt:
+              description: |
+                Carimbo do tempo do momento da última atualização do registro
+              type: string
+              format: date-time
+              maxLength: 28
+
+    PrivateReportEndpoints:
+      description: |
+        Identificação do endpoint que foi utilizado na transação reportada. A identificação do endpoint deve estar entre as entradas desse enum para ser considerado válido. Nesse campo não deve ser utilizado o _path_ da requisição original, uma vez que ao comparar com os valores dessa enum, ele não será considerado válido.
+
+        Exemplo:
+
+        1. Caso uma chamada à um endpoint com o **path** `/open-banking/credit-cards-accounts/v1/accounts/123456789/transactions` tenha sido feita, o valor a ser enviado no reporte é `/open-banking/credit-cards-accounts/v1/accounts/{creditCardAccountId}/transactions`, que é o identificador desse endpoint no enum. Nesse caso, o dado real da parte variável do _path_ não deverá ser enviado.
+      type: string
+      example: /open-banking/consents/v2/consents
+      enum:
+        - "/token"
+        - "/register"
+        - "/register/{clientId}"
+        - "/introspection"
+        - "/pushed-authorization-request"
+        - "/revocation"
+        - "/open-banking/accounts/v2/accounts"
+        - "/open-banking/accounts/v2/accounts/{accountId}"
+        - "/open-banking/accounts/v2/accounts/{accountId}/balances"
+        - "/open-banking/accounts/v2/accounts/{accountId}/overdraft-limits"
+        - "/open-banking/accounts/v2/accounts/{accountId}/transactions"
+        - "/open-banking/accounts/v2/accounts/{accountId}/transactions-current"
+        - "/open-banking/consents/v2/consents"
+        - "/open-banking/consents/v2/consents/{consentId}"
+        - "/open-banking/credit-cards-accounts/v2/accounts"
+        - "/open-banking/credit-cards-accounts/v2/accounts/{creditCardAccountId}"
+        - "/open-banking/credit-cards-accounts/v2/accounts/{creditCardAccountId}/bills"
+        - "/open-banking/credit-cards-accounts/v2/accounts/{creditCardAccountId}/bills/{billId}/transactions"
+        - "/open-banking/credit-cards-accounts/v2/accounts/{creditCardAccountId}/limits"
+        - "/open-banking/credit-cards-accounts/v2/accounts/{creditCardAccountId}/transactions"
+        - "/open-banking/credit-cards-accounts/v2/accounts/{creditCardAccountId}/transactions-current"
+        - "/open-banking/customers/v2/business/financial-relations"
+        - "/open-banking/customers/v2/business/identifications"
+        - "/open-banking/customers/v2/business/qualifications"
+        - "/open-banking/customers/v2/personal/financial-relations"
+        - "/open-banking/customers/v2/personal/identifications"
+        - "/open-banking/customers/v2/personal/qualifications"
+        - "/open-banking/financings/v2/contracts"
+        - "/open-banking/financings/v2/contracts/{contractId}"
+        - "/open-banking/financings/v2/contracts/{contractId}/payments"
+        - "/open-banking/financings/v2/contracts/{contractId}/scheduled-instalments"
+        - "/open-banking/financings/v2/contracts/{contractId}/warranties"
+        - "/open-banking/invoice-financings/v2/contracts"
+        - "/open-banking/invoice-financings/v2/contracts/{contractId}"
+        - "/open-banking/invoice-financings/v2/contracts/{contractId}/payments"
+        - "/open-banking/invoice-financings/v2/contracts/{contractId}/scheduled-instalments"
+        - "/open-banking/invoice-financings/v2/contracts/{contractId}/warranties"
+        - "/open-banking/loans/v2/contracts"
+        - "/open-banking/loans/v2/contracts/{contractId}"
+        - "/open-banking/loans/v2/contracts/{contractId}/payments"
+        - "/open-banking/loans/v2/contracts/{contractId}/scheduled-instalments"
+        - "/open-banking/loans/v2/contracts/{contractId}/warranties"
+        - "/open-banking/payments/v1/consents"
+        - "/open-banking/payments/v1/consents/{consentId}"
+        - "/open-banking/payments/v1/pix/payments"
+        - "/open-banking/payments/v1/pix/payments/{paymentId}"
+        - "/open-banking/payments/v2/consents"
+        - "/open-banking/payments/v2/consents/{consentId}"
+        - "/open-banking/payments/v2/pix/payments"
+        - "/open-banking/payments/v2/pix/payments/{paymentId}"
+        - "/open-banking/resources/v2/resources"
+        - "/open-banking/unarranged-accounts-overdraft/v2/contracts"
+        - "/open-banking/unarranged-accounts-overdraft/v2/contracts/{contractId}"
+        - "/open-banking/unarranged-accounts-overdraft/v2/contracts/{contractId}/payments"
+        - "/open-banking/unarranged-accounts-overdraft/v2/contracts/{contractId}/scheduled-instalments"
+        - "/open-banking/unarranged-accounts-overdraft/v2/contracts/{contractId}/warranties"
+        - "/open-banking/payments/v3/consents"
+        - "/open-banking/payments/v3/consents/{consentId}"
+        - "/open-banking/payments/v3/pix/payments"
+        - "/open-banking/payments/v3/pix/payments/{paymentId}"
+        - "/open-banking/automatic-payments/v2/recurring-consents"
+        - "/open-banking/automatic-payments/v2/recurring-consents/{recurringConsentId}"
+        - "/open-banking/automatic-payments/v2/pix/recurring-payments"
+        - "/open-banking/automatic-payments/v2/pix/recurring-payments/{recurringPaymentId}"
+
+    OpendataReportEndpoints:
+      description: |
+        Identificação do endpoint que foi utilizado na chamada da api de dados abertos. A identificação do endpoint deve estar entre as entradas desse enum para ser considerado válido.
+      type: string
+      example: "/open-banking/channels/v1/electronic-channels"
+      enum:
+        - "/open-banking/opendata-accounts/v1/personal-accounts"
+        - "/open-banking/opendata-accounts/v1/business-accounts"
+        - "/open-banking/opendata-loans/v1/personal-loans"
+        - "/open-banking/opendata-loans/v1/business-loans"
+        - "/open-banking/opendata-financings/v1/personal-financings"
+        - "/open-banking/opendata-financings/v1/business-financings"
+        - "/open-banking/opendata-invoicefinancings/v1/personal-invoice-financings"
+        - "/open-banking/opendata-invoicefinancings/v1/business-invoice-financings"
+        - "/open-banking/opendata-creditcards/v1/personal-credit-cards"
+        - "/open-banking/opendata-creditcards/v1/business-credit-cards"
+        - "/open-banking/opendata-unarranged/v1/personal-unarranged-account-overdraft"
+        - "/open-banking/opendata-unarranged/v1/business-unarranged-account-overdraft"
+        - "/open-banking/channels/v2/branches"
+        - "/open-banking/channels/v2/electronic-channels"
+        - "/open-banking/channels/v2/phone-channels"
+        - "/open-banking/channels/v2/banking-agents"
+        - "/open-banking/channels/v2/shared-automated-teller-machines"
+        - "/open-banking/capitalization-bonds/v2/bonds"
+        - "/open-banking/investments/v1/funds"
+        - "/open-banking/exchange/v1/online-rates"
+        - "/open-banking/exchange/v1/vet-values"
+        - "/open-banking/acquiring-services/v1/personals"
+        - "/open-banking/acquiring-services/v1/businesses"
+        - "/open-banking/pension/v2/risk-coverages"
+        - "/open-banking/pension/v2/survival-coverages"
+        - "/open-banking/insurance/v2/personals"
+        - "/open-banking/pension/v1/risk-coverages"
+        - "/open-banking/insurance/v1/automotives"
+        - "/open-banking/insurance/v1/homes"
+        - "/open-banking/insurance/v1/personals"
+        - "/open-banking/opendata-capitalization/v2/bonds"
+        - "/open-banking/opendata-pension/v2/risk-coverages"
+        - "/open-banking/opendata-pension/v2/survival-coverages"
+        - "/open-banking/opendata-insurance/v2/personals"
+        - "/open-banking/opendata-investments/v1/funds"
+        - "/open-banking/opendata-investments/v1/bank-fixed-incomes"
+        - "/open-banking/opendata-investments/v1/credit-fixed-incomes"
+        - "/open-banking/opendata-investments/v1/variable-incomes"
+        - "/open-banking/opendata-investments/v1/treasure-titles"
+        - "/open-banking/opendata-exchange/v1/online-rates"
+        - "/open-banking/opendata-exchange/v1/vet-values"
+        - "/open-banking/opendata-acquiring-services/v1/personals"
+        - "/open-banking/opendata-acquiring-services/v1/businesses"
+
+    AdditionalInfo:
+      description: Informações adicionais sobre o reporte deste endpoint/método. Possui característica variável. As regras de preenchimento estão na documentação funcional em [https://openfinancebrasil.atlassian.net/wiki/spaces/OF/pages/806158355/Planilha+AdditionalInfo](https://openfinancebrasil.atlassian.net/wiki/spaces/OF/pages/806158355/Planilha+AdditionalInfo). Atenção especial na tabela Excel com a listagem de endpoints em [https://openfinancebrasil.atlassian.net/wiki/spaces/OF/pages/806158355/Planilha+AdditionalInfo](https://openfinancebrasil.atlassian.net/wiki/spaces/OF/pages/806158355/Planilha+AdditionalInfo).
+      type: object
+
+      properties:
+        consentId:
+          description: Deve ser preenchido com a mesma string obtida no campo `.data.consentId` retornado após a chamada inicial na API "POST /consent". *Ao reportar o uso de um endpoint /token, o identificador único de consentimento só será reportado nos casos em que "grant_type" é do tipo "authorization_code" ou do tipo "refresh_token", uma vez que esta informação de consentId é inexistente quando "grant_type" é do tipo
+          type: string
+        personType:
+          description: Deve ser preenchida baseado no tipo de pessoa responsável pelo consentimento. Deverá ser observado se `.data.businessEntity` estiver preenchido no payload, se estiver então preencher com "PJ", se não estiver então preencher com "PF"
+          type: string
+          enum:
+            - PF
+            - PJ
+        localInstrument:
+          description: Deve ser preenchido com a mesma string informada no payload ".data.localInstrument"
+          type: string
+        status:
+          description: Deve ser preenchido com a mesma string obtida no ".data.status"
+          type: string
+        clientIp:
+          description: Deve ser preenchido com o Endereço IPv4 ou IPv6 do client que fez a requisição
+          type: string
+        rejectReason:
+          description: Deve ser preenchido com a mesma string obtida no ".data.rejectionReason.code"
+          type: string
+        errorCodes:
+          description: Caso o HTTP Code seja 4XX ou 5XX, esse campo deve ser preenchido com a lista das strings obtidas em ".errors[].code" . Não havendo string, deve ser enviada uma lista vazia.
+          type: string
+        webhookEnable:
+          description: Deve ser preenchido com o valor booleano TRUE caso haja pelo menos um item indicado na lista do campo ".webhook_uris" no payload, caso contrário deverá ser preenchido com o valor booleano FALSE
+          type: string
+        webhookInteractionId:
+          description: Caso o GET esteja sendo feito após o estímulo do webhook, o x-webhook-interaction-id deverá ser indicado
+          type: string
+        enrollmentId:
+          description: Deve ser preenchido com a mesma string obtida no campo `.data.enrollmentId` retornado após a chamada inicial na API "POST /enrollments". *Ao reportar o uso de um endpoint /token, o identificador único de consentimento só será reportado nos casos em que "grant_type" é do tipo "authorization_code" ou do tipo "refresh_token", uma vez que esta informação de enrollmentId é inexistente quando "grant_type" é do tipo "client_credentials".
+          type: string
+        authenticatorAttachment:
+          description: Deve ser preenchido com a mesma string definida em ".data.authenticatorAttachment".  Não havendo string, deve ser explicitamente enviada esse additionalInfo como sendo uma string vazia.
+          type: string
+        platform:
+          description: Deve ser preenchido com a mesma string definida em ".data.platform"
+          type: string
+        rp:
+          description: Deve ser preenchido com a mesma string definida em ".data.rp"
+          type: string
+        rejectionReasonCode:
+          description: Deve ser preenchido com a mesma string obtida no ".data.rejectionReason.code"
+          type: string
+        rejectionReasonDetail:
+          description: Deve ser preenchido com a mesma string obtida no ".data.rejectionReason.detail"
+          type: string
+        authorisationFlow:
+          description: Deve ser preenchido com a mesma string obtida no ".data.authorisationFlow"
+          type: string
+        dropReason:
+          description: |
+            Regras:
+              - O campo dropReason deve ser adicionado nas informações do campo additionalInfo que deverá ser enviado no reporte do provedor do serviço consumido (papel SERVER) 
+              - O reporte deverá ser feito por todos os transmissores de dados e detentoras de conta. Para os casos em que ocorram falhas técnicas que impossibilitem a verificação do CPF/CNPJ (incluindo, mas não se limitando, a erros HTTP 4xx, 500 ou timeout na resposta), o reporte deve ser realizado com o valor NO_CREDENTIAL, Em jornadas de múltipla alçada de pessoas jurídicas, quando a autenticação é bem-sucedida mas os poderes constituídos são insuficientes para finalização do Hybrid Flow, deve-se usar NO_AUTHORITY.
+                
+            Diretrizes:
+            
+              - `NONE`: quando o CPF (loggedUser) / CNPJ (businessEntity) possui credencial autenticadora e poderes suficientes para prosseguir o fluxo monitorado - exemplo: PF, cliente, que possui credencial ativa, mas não se autenticou; cliente que se autenticou utilizando a credencial correta. 
+              - `NO_CREDENTIAL`: quando o CPF (loggedUser) / CNPJ (businessEntity) não for cliente ou não possuir credencial válida/ativa para prosseguir no fluxo monitorado ou quando o HTTP response code for diferente de 201.
+              - `NO_AUTHORITY`: quando o CPF (loggedUser) / CNPJ (businessEntity) consegue se autenticar, mas não dispõe de poderes ou alçadas para prosseguir no fluxo de compartilhamento de dados e serviços. 
+              - `NO_AUTHORITY_PERSON_MISMATCH`: quando o CPF (loggedUser) não possui relação com a credencial utilizada na etapa de autenticação do Hybrid Flow - exemplo: consentimento criado para um CPF e autenticado por outro; criado para um CNPJ e autenticado por CPF sem relação com o CNPJ. 
+              
+          type: string
+        paymentType:
+          description: |
+            Identifica o modo de pagamento acionado no consentimento
+            1. Envio obrigatório para a role Client​
+            2. Conteudo ENUM do novo campo varia de acordo com o endpoint conforme tabela abaixo
+
+            | Endpoint | Valores possíveis |
+            |----------|-------------|
+            | <br>POST /open-banking/payments/v4/consents&nbsp;&nbsp;&nbsp;    |  <br>IMMEDIATE<br>SCHEDULED<br>RECURRENT
+            |----------|-------------|
+            | <br>POST /open-banking/payments/v4/pix/payments&nbsp;&nbsp;&nbsp;    |  <br>IMMEDIATE<br>SCHEDULED<br>RECURRENT
+            |----------|-------------|
+            | <br>PATCH /open-banking/payments/v4/pix/payments/{paymentId}​&nbsp;&nbsp;&nbsp;    |  <br>IMMEDIATE<br>SCHEDULED<br>RECURRENT
+            |----------|-------------|
+            | <br>POST /automatic-payments/v1/recurring-consents&nbsp;&nbsp;&nbsp;    |  <br>SWEEPING
+            |----------|-------------|
+            | <br>PATCH /automatic-payments/v1/recurring-consents/{consentId}&nbsp;&nbsp;&nbsp;    |  <br>SWEEPING
+            |----------|-------------|
+            | <br>POST /automatic-payments/v1/pix/recurring-payments&nbsp;&nbsp;&nbsp;    |  <br>SWEEPING
+            |----------|-------------|
+            | <br>PATCH /automatic-payments/v1/pix/recurring-payments/{paymentId}&nbsp;&nbsp;&nbsp;   |  <br>SWEEPING
+            |----------|-------------|
+            | <br>POST /open-banking/automatic-payments/v2/recurring-consents&nbsp;&nbsp;&nbsp;   |  <br>SWEEPING<br>AUTOMATIC
+            |----------|-------------|
+            | <br>POST /open-banking/automatic-payments/v2/recurring-consents/{recurringConsentId}&nbsp;&nbsp;&nbsp;   |  <br>SWEEPING<br>AUTOMATIC
+            |----------|-------------|
+            | <br>POST /open-banking/automatic-payments/v2/pix/recurring-payments&nbsp;&nbsp;&nbsp;   |  <br>SWEEPING<br>AUTOMATIC
+            |----------|-------------|
+            | <br>POST /open-banking/automatic-payments/v2/pix/recurring-payments/{recurringPaymentId}&nbsp;&nbsp;&nbsp;   |  <br>SWEEPING<br>AUTOMATIC
+            |----------|-------------|
+            | <br>GET /open-banking/automatic-payments/v2/recurring-consents&nbsp;&nbsp;&nbsp;   |  <br>SWEEPING<br>AUTOMATIC
+            |----------|-------------|
+            | <br>GET /open-banking/automatic-payments/v2/recurring-consents/{recurringConsentId}&nbsp;&nbsp;&nbsp;   |  <br>SWEEPING<br>AUTOMATIC
+            |----------|-------------|
+            | <br>GET /open-banking/automatic-payments/v2/pix/recurring-payments&nbsp;&nbsp;&nbsp;   |  <br>SWEEPING<br>AUTOMATIC
+            |----------|-------------|
+            | <br>GET /open-banking/automatic-payments/v2/pix/recurring-payments/{recurringPaymentId}&nbsp;&nbsp;&nbsp;   |  <br>SWEEPING<br>AUTOMATIC
+            |----------|-------------|
+            | <br>PATCH /open-banking/automatic-payments/v2/recurring-consents&nbsp;&nbsp;&nbsp;   |  <br>SWEEPING<br>AUTOMATIC
+            |----------|-------------|
+            | <br>PATCH /open-banking/automatic-payments/v2/recurring-consents/{recurringConsentId}&nbsp;&nbsp;&nbsp;   |  <br>SWEEPING<br>AUTOMATIC
+            |----------|-------------|
+            | <br>PATCH /open-banking/automatic-payments/v2/pix/recurring-payments&nbsp;&nbsp;&nbsp;   |  <br>SWEEPING<br>AUTOMATIC
+            |----------|-------------|
+            | <br>PATCH /open-banking/automatic-payments/v2/pix/recurring-payments/{recurringPaymentId}&nbsp;&nbsp;&nbsp;   |  <br>SWEEPING<br>AUTOMATIC
+            
+            <br>
+            Identifica o modo de pagamento acionado no consentimento.
+            Valores possíveis:
+            - `IMMEDIATE`: Pix sem configuração de agendamento
+            - `SCHEDULED`: Pix com configuração de agendamento
+            - `RECURRENT`: Pix com agendamento e recorrência
+            - `SWEEPING`: Chamadas de pagamentos inteligentes
+            - `AUTOMATIC`: Pagamentos automáticos
+            <br>
+          type: string
+          enum:
+            - IMMEDIATE
+            - SCHEDULED
+            - RECURRENT​
+            - SWEEPING
+          x-enum-descriptions:
+            - Pix sem configuração de agendamento​
+            - Pix com configuração de agendamento​
+            - Pix sem configuração de agendamento e configuração de recorrência​
+            - para todas as chamadas de pagamentos inteligentes​
+        revocationReasonCode:
+          description: |
+            Código indicador do motivo da revogação
+
+            | Endpoint  | Descrição Jornada | Obrigatoriedade Client  | Obrigatoriedade Server  |
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | POST /automatic-payments/v1/recurring-consents                  | Criar consentimento para iniciação de pagamento​                                                                              | -                                    | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | GET /automatic-payments/v1/recurring-consents/{consentId}​       | Consultar consentimento para iniciação de pagamento​​                                                                          | Se revogation: {RevocationReasonCode, RevocationReasonDetail, RevokedBy, RevokedFrom}​ <br> Se rejected: {RejectedBy, RejectedFrom}​        | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | PATCH /automatic-payments/v1/recurring-consents/{consentId}​     | Rejeita, revoga ou edita um consentimento​          ​                                                                          | Se revogation: {RevocationReasonCode, RevocationReasonDetail, RevokedBy, RevokedFrom}​ <br> Se rejected: {RejectedBy, RejectedFrom}​        | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |        
+            | POST /automatic-payments/v1/pix/recurring-payments​​              | Pix - Criar iniciação de pagamento limitada por parametrização de tempo ou limite total realizada no consentimento​​           | -                                  
+            | --------- | ----------------- | ----------------------- | ----------------------- |        
+            | GET /automatic-payments/v1/pix/recurring-payments?consentId=​    | Pix – Consulta informações de transações de pagamentos associadas a um consentimento​                                         | -                                
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | GET /automatic-payments/v1/pix/recurring-payments/{paymentId}​   | Pix - Consultar iniciação de pagamento​                                                                                       | -                                    | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | PATCH /automatic-payments/v1/pix/recurring-payments/{paymentId}​ | Pix - Cancelar iniciação de pagamento​​                                                                                        | Será necessário o reporte porém temos que aguardar a <br> definição do nome do campo pelo GT Especificações Serviços​                      | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | POST /open-banking/automatic-payments/v2/recurring-consents     | Criar consentimento para iniciação de pagamento​                                                                              | -                                    | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | GET /open-banking/automatic-payments/v2/recurring-consents/{recurringConsentId}​       | Consultar consentimento para iniciação de pagamento​​                                                                          | Se revogation: {RevocationReasonCode, RevocationReasonDetail, RevokedBy, RevokedFrom}​ <br> Se rejected: {RejectedBy, RejectedFrom}​        | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | PATCH /open-banking/automatic-payments/v2/recurring-consents/{recurringConsentId}​     | Rejeita, revoga ou edita um consentimento​          ​                                                                          | Se revogation: {RevocationReasonCode, RevocationReasonDetail, RevokedBy, RevokedFrom}​ <br> Se rejected: {RejectedBy, RejectedFrom}​        | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |        
+            | POST /open-banking/automatic-payments/v2/pix/recurring-payments​​              | Pix - Criar iniciação de pagamento limitada por parametrização de tempo ou limite total realizada no consentimento​​           | -                                  
+            | --------- | ----------------- | ----------------------- | ----------------------- |        
+            | GET /open-banking/automatic-payments/v2/pix/recurring-payments/{recurringPaymentId}​   | Pix - Consultar iniciação de pagamento​                                                                                       | -                                    | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | PATCH /open-banking/automatic-payments/v2/pix/recurring-payments/{recurringPaymentId}​ | Pix - Cancelar iniciação de pagamento​​                                                                                        | Será necessário o reporte porém temos que aguardar a <br> definição do nome do campo pelo GT Especificações Serviços​                      | -
+            <br>
+           
+          type: string
+        revocationReasonDetail:
+          description: |
+            Detalhe sobre o motivo de revogação indicado no campo
+
+            | Endpoint  | Descrição Jornada | Obrigatoriedade Client  | Obrigatoriedade Server  |
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | POST /automatic-payments/v1/recurring-consents                  | Criar consentimento para iniciação de pagamento​                                                                              | -                                    | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | GET /automatic-payments/v1/recurring-consents/{consentId}​       | Consultar consentimento para iniciação de pagamento​​                                                                          | Se revogation: {RevocationReasonCode, RevocationReasonDetail, RevokedBy, RevokedFrom}​ <br> Se rejected: {RejectedBy, RejectedFrom}​        | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | PATCH /automatic-payments/v1/recurring-consents/{consentId}​     | Rejeita, revoga ou edita um consentimento​          ​                                                                          | Se revogation: {RevocationReasonCode, RevocationReasonDetail, RevokedBy, RevokedFrom}​ <br> Se rejected: {RejectedBy, RejectedFrom}​        | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |        
+            | POST /automatic-payments/v1/pix/recurring-payments​​              | Pix - Criar iniciação de pagamento limitada por parametrização de tempo ou limite total realizada no consentimento​​           | -                                  
+            | --------- | ----------------- | ----------------------- | ----------------------- |        
+            | GET /automatic-payments/v1/pix/recurring-payments?consentId=​    | Pix – Consulta informações de transações de pagamentos associadas a um consentimento​                                         | -                                
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | GET /automatic-payments/v1/pix/recurring-payments/{paymentId}​   | Pix - Consultar iniciação de pagamento​                                                                                       | -                                    | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | PATCH /automatic-payments/v1/pix/recurring-payments/{paymentId}​ | Pix - Cancelar iniciação de pagamento​​                                                                                        | Será necessário o reporte porém temos que aguardar a <br> definição do nome do campo pelo GT Especificações Serviços​                      | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | POST /open-banking/automatic-payments/v2/recurring-consents     | Criar consentimento para iniciação de pagamento​                                                                              | -                                    | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | GET /open-banking/automatic-payments/v2/recurring-consents/{recurringConsentId}​       | Consultar consentimento para iniciação de pagamento​​                                                                          | Se revogation: {RevocationReasonCode, RevocationReasonDetail, RevokedBy, RevokedFrom}​ <br> Se rejected: {RejectedBy, RejectedFrom}​        | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | PATCH /open-banking/automatic-payments/v2/recurring-consents/{recurringConsentId}​     | Rejeita, revoga ou edita um consentimento​          ​                                                                          | Se revogation: {RevocationReasonCode, RevocationReasonDetail, RevokedBy, RevokedFrom}​ <br> Se rejected: {RejectedBy, RejectedFrom}​        | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |        
+            | POST /open-banking/automatic-payments/v2/pix/recurring-payments​​              | Pix - Criar iniciação de pagamento limitada por parametrização de tempo ou limite total realizada no consentimento​​           | -                                  
+            | --------- | ----------------- | ----------------------- | ----------------------- |        
+            | GET /open-banking/automatic-payments/v2/pix/recurring-payments/{recurringPaymentId}​   | Pix - Consultar iniciação de pagamento​                                                                                       | -                                    | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | PATCH /open-banking/automatic-payments/v2/pix/recurring-payments/{recurringPaymentId}​ | Pix - Cancelar iniciação de pagamento​​                                                                                        | Será necessário o reporte porém temos que aguardar a <br> definição do nome do campo pelo GT Especificações Serviços​                      | -
+            
+            <br>
+
+          type: string
+        revokedBy:
+          description: |
+            Quem iniciou a solicitação de revogação 
+
+            | Endpoint  | Descrição Jornada | Obrigatoriedade Client  | Obrigatoriedade Server  |
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | POST /automatic-payments/v1/recurring-consents                  | Criar consentimento para iniciação de pagamento​                                                                              | -                                    | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | GET /automatic-payments/v1/recurring-consents/{consentId}​       | Consultar consentimento para iniciação de pagamento​​                                                                          | Se revogation: {RevocationReasonCode, RevocationReasonDetail, RevokedBy, RevokedFrom}​ <br> Se rejected: {RejectedBy, RejectedFrom}​        | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | PATCH /automatic-payments/v1/recurring-consents/{consentId}​     | Rejeita, revoga ou edita um consentimento​          ​                                                                          | Se revogation: {RevocationReasonCode, RevocationReasonDetail, RevokedBy, RevokedFrom}​ <br> Se rejected: {RejectedBy, RejectedFrom}​        | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |        
+            | POST /automatic-payments/v1/pix/recurring-payments​​              | Pix - Criar iniciação de pagamento limitada por parametrização de tempo ou limite total realizada no consentimento​​           | -                                  
+            | --------- | ----------------- | ----------------------- | ----------------------- |        
+            | GET /automatic-payments/v1/pix/recurring-payments?consentId=​    | Pix – Consulta informações de transações de pagamentos associadas a um consentimento​                                         | -                                
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | GET /automatic-payments/v1/pix/recurring-payments/{paymentId}​   | Pix - Consultar iniciação de pagamento​                                                                                       | -                                    | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | PATCH /automatic-payments/v1/pix/recurring-payments/{paymentId}​ | Pix - Cancelar iniciação de pagamento​​                                                                                        | Será necessário o reporte porém temos que aguardar a <br> definição do nome do campo pelo GT Especificações Serviços​                      | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | POST /open-banking/automatic-payments/v2/recurring-consents     | Criar consentimento para iniciação de pagamento​                                                                              | -                                    | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | GET /open-banking/automatic-payments/v2/recurring-consents/{recurringConsentId}​       | Consultar consentimento para iniciação de pagamento​​                                                                          | Se revogation: {RevocationReasonCode, RevocationReasonDetail, RevokedBy, RevokedFrom}​ <br> Se rejected: {RejectedBy, RejectedFrom}​        | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | PATCH /open-banking/automatic-payments/v2/recurring-consents/{recurringConsentId}​     | Rejeita, revoga ou edita um consentimento​          ​                                                                          | Se revogation: {RevocationReasonCode, RevocationReasonDetail, RevokedBy, RevokedFrom}​ <br> Se rejected: {RejectedBy, RejectedFrom}​        | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |        
+            | POST /open-banking/automatic-payments/v2/pix/recurring-payments​​              | Pix - Criar iniciação de pagamento limitada por parametrização de tempo ou limite total realizada no consentimento​​           | -                                  
+            | --------- | ----------------- | ----------------------- | ----------------------- |        
+            | GET /open-banking/automatic-payments/v2/pix/recurring-payments/{recurringPaymentId}​   | Pix - Consultar iniciação de pagamento​                                                                                       | -                                    | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | PATCH /open-banking/automatic-payments/v2/pix/recurring-payments/{recurringPaymentId}​ | Pix - Cancelar iniciação de pagamento​​                                                                                        | Será necessário o reporte porém temos que aguardar a <br> definição do nome do campo pelo GT Especificações Serviços​                      | -
+            
+            <br>
+
+          type: string
+          enum:
+            - INICIADORA
+            - USUARIO
+            - DETENTORA
+        revokedFrom:
+          description: |
+            Canal onde iniciou-se o processo de revogação
+
+            | Endpoint  | Descrição Jornada | Obrigatoriedade Client  | Obrigatoriedade Server  |
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | POST /automatic-payments/v1/recurring-consents                  | Criar consentimento para iniciação de pagamento​                                                                              | -                                    | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | GET /automatic-payments/v1/recurring-consents/{consentId}​       | Consultar consentimento para iniciação de pagamento​​                                                                          | Se revogation: {RevocationReasonCode, RevocationReasonDetail, RevokedBy, RevokedFrom}​ <br> Se rejected: {RejectedBy, RejectedFrom}​        | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | PATCH /automatic-payments/v1/recurring-consents/{consentId}​     | Rejeita, revoga ou edita um consentimento​          ​                                                                          | Se revogation: {RevocationReasonCode, RevocationReasonDetail, RevokedBy, RevokedFrom}​ <br> Se rejected: {RejectedBy, RejectedFrom}​        | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |        
+            | POST /automatic-payments/v1/pix/recurring-payments​​              | Pix - Criar iniciação de pagamento limitada por parametrização de tempo ou limite total realizada no consentimento​​           | -                                  
+            | --------- | ----------------- | ----------------------- | ----------------------- |        
+            | GET /automatic-payments/v1/pix/recurring-payments?consentId=​    | Pix – Consulta informações de transações de pagamentos associadas a um consentimento​                                         | -                                
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | GET /automatic-payments/v1/pix/recurring-payments/{paymentId}​   | Pix - Consultar iniciação de pagamento​                                                                                       | -                                    | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | PATCH /automatic-payments/v1/pix/recurring-payments/{paymentId}​ | Pix - Cancelar iniciação de pagamento​​                                                                                        | Será necessário o reporte porém temos que aguardar a <br> definição do nome do campo pelo GT Especificações Serviços​                      | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | POST /open-banking/automatic-payments/v2/recurring-consents     | Criar consentimento para iniciação de pagamento​                                                                              | -                                    | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | GET /open-banking/automatic-payments/v2/recurring-consents/{recurringConsentId}​       | Consultar consentimento para iniciação de pagamento​​                                                                          | Se revogation: {RevocationReasonCode, RevocationReasonDetail, RevokedBy, RevokedFrom}​ <br> Se rejected: {RejectedBy, RejectedFrom}​        | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | PATCH /open-banking/automatic-payments/v2/recurring-consents/{recurringConsentId}​     | Rejeita, revoga ou edita um consentimento​          ​                                                                          | Se revogation: {RevocationReasonCode, RevocationReasonDetail, RevokedBy, RevokedFrom}​ <br> Se rejected: {RejectedBy, RejectedFrom}​        | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |        
+            | POST /open-banking/automatic-payments/v2/pix/recurring-payments​​              | Pix - Criar iniciação de pagamento limitada por parametrização de tempo ou limite total realizada no consentimento​​           | -                                  
+            | --------- | ----------------- | ----------------------- | ----------------------- |        
+            | GET /open-banking/automatic-payments/v2/pix/recurring-payments/{recurringPaymentId}​   | Pix - Consultar iniciação de pagamento​                                                                                       | -                                    | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | PATCH /open-banking/automatic-payments/v2/pix/recurring-payments/{recurringPaymentId}​ | Pix - Cancelar iniciação de pagamento​​                                                                                        | Será necessário o reporte porém temos que aguardar a <br> definição do nome do campo pelo GT Especificações Serviços​                      | -
+            
+            <br>
+
+          type: string
+          enum:
+            - INICIADORA
+            - DETENTORA
+        rejectedBy:
+          description: |
+            Quem iniciou a solicitação de rejeição
+
+            | Endpoint  | Descrição Jornada | Obrigatoriedade Client  | Obrigatoriedade Server  |
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | POST /automatic-payments/v1/recurring-consents                  | Criar consentimento para iniciação de pagamento​                                                                              | -                                    | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | GET /automatic-payments/v1/recurring-consents/{consentId}​       | Consultar consentimento para iniciação de pagamento​​                                                                          | Se revogation: {RevocationReasonCode, RevocationReasonDetail, RevokedBy, RevokedFrom}​ <br> Se rejected: {RejectedBy, RejectedFrom}​        | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | PATCH /automatic-payments/v1/recurring-consents/{consentId}​     | Rejeita, revoga ou edita um consentimento​          ​                                                                          | Se revogation: {RevocationReasonCode, RevocationReasonDetail, RevokedBy, RevokedFrom}​ <br> Se rejected: {RejectedBy, RejectedFrom}​        | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |        
+            | POST /automatic-payments/v1/pix/recurring-payments​​              | Pix - Criar iniciação de pagamento limitada por parametrização de tempo ou limite total realizada no consentimento​​           | -                                  
+            | --------- | ----------------- | ----------------------- | ----------------------- |        
+            | GET /automatic-payments/v1/pix/recurring-payments?consentId=​    | Pix – Consulta informações de transações de pagamentos associadas a um consentimento​                                         | -                                
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | GET /automatic-payments/v1/pix/recurring-payments/{paymentId}​   | Pix - Consultar iniciação de pagamento​                                                                                       | -                                    | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | PATCH /automatic-payments/v1/pix/recurring-payments/{paymentId}​ | Pix - Cancelar iniciação de pagamento​​                                                                                        | Será necessário o reporte porém temos que aguardar a <br> definição do nome do campo pelo GT Especificações Serviços​                      | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | POST /open-banking/automatic-payments/v2/recurring-consents     | Criar consentimento para iniciação de pagamento​                                                                              | -                                    | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | GET /open-banking/automatic-payments/v2/recurring-consents/{recurringConsentId}​       | Consultar consentimento para iniciação de pagamento​​                                                                          | Se revogation: {RevocationReasonCode, RevocationReasonDetail, RevokedBy, RevokedFrom}​ <br> Se rejected: {RejectedBy, RejectedFrom}​        | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | PATCH /open-banking/automatic-payments/v2/recurring-consents/{recurringConsentId}​     | Rejeita, revoga ou edita um consentimento​          ​                                                                          | Se revogation: {RevocationReasonCode, RevocationReasonDetail, RevokedBy, RevokedFrom}​ <br> Se rejected: {RejectedBy, RejectedFrom}​        | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |        
+            | POST /open-banking/automatic-payments/v2/pix/recurring-payments​​              | Pix - Criar iniciação de pagamento limitada por parametrização de tempo ou limite total realizada no consentimento​​           | -                                  
+            | --------- | ----------------- | ----------------------- | ----------------------- |        
+            | GET /open-banking/automatic-payments/v2/pix/recurring-payments/{recurringPaymentId}​   | Pix - Consultar iniciação de pagamento​                                                                                       | -                                    | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | PATCH /open-banking/automatic-payments/v2/pix/recurring-payments/{recurringPaymentId}​ | Pix - Cancelar iniciação de pagamento​​                                                                                        | Será necessário o reporte porém temos que aguardar a <br> definição do nome do campo pelo GT Especificações Serviços​                      | -
+            
+            <br>
+
+          type: string
+          enum:
+            - INICIADORA
+            - USUARIO
+            - DETENTORA
+        rejectedFrom:
+          description: |
+            Canal onde iniciou-se o processo de rejeição
+
+            | Endpoint  | Descrição Jornada | Obrigatoriedade Client  | Obrigatoriedade Server  |
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | POST /automatic-payments/v1/recurring-consents                  | Criar consentimento para iniciação de pagamento​                                                                              | -                                    | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | GET /automatic-payments/v1/recurring-consents/{consentId}​       | Consultar consentimento para iniciação de pagamento​​                                                                          | Se revogation: {RevocationReasonCode, RevocationReasonDetail, RevokedBy, RevokedFrom}​ <br> Se rejected: {RejectedBy, RejectedFrom}​        | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | PATCH /automatic-payments/v1/recurring-consents/{consentId}​     | Rejeita, revoga ou edita um consentimento​          ​                                                                          | Se revogation: {RevocationReasonCode, RevocationReasonDetail, RevokedBy, RevokedFrom}​ <br> Se rejected: {RejectedBy, RejectedFrom}​        | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |        
+            | POST /automatic-payments/v1/pix/recurring-payments​​              | Pix - Criar iniciação de pagamento limitada por parametrização de tempo ou limite total realizada no consentimento​​           | -                                  
+            | --------- | ----------------- | ----------------------- | ----------------------- |        
+            | GET /automatic-payments/v1/pix/recurring-payments?consentId=​    | Pix – Consulta informações de transações de pagamentos associadas a um consentimento​                                         | -                                
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | GET /automatic-payments/v1/pix/recurring-payments/{paymentId}​   | Pix - Consultar iniciação de pagamento​                                                                                       | -                                    | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | PATCH /automatic-payments/v1/pix/recurring-payments/{paymentId}​ | Pix - Cancelar iniciação de pagamento​​                                                                                        | Será necessário o reporte porém temos que aguardar a <br> definição do nome do campo pelo GT Especificações Serviços​                      | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | POST /open-banking/automatic-payments/v2/recurring-consents     | Criar consentimento para iniciação de pagamento​                                                                              | -                                    | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | GET /open-banking/automatic-payments/v2/recurring-consents/{recurringConsentId}​       | Consultar consentimento para iniciação de pagamento​​                                                                          | Se revogation: {RevocationReasonCode, RevocationReasonDetail, RevokedBy, RevokedFrom}​ <br> Se rejected: {RejectedBy, RejectedFrom}​        | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | PATCH /open-banking/automatic-payments/v2/recurring-consents/{recurringConsentId}​     | Rejeita, revoga ou edita um consentimento​          ​                                                                          | Se revogation: {RevocationReasonCode, RevocationReasonDetail, RevokedBy, RevokedFrom}​ <br> Se rejected: {RejectedBy, RejectedFrom}​        | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |        
+            | POST /open-banking/automatic-payments/v2/pix/recurring-payments​​              | Pix - Criar iniciação de pagamento limitada por parametrização de tempo ou limite total realizada no consentimento​​           | -                                  
+            | --------- | ----------------- | ----------------------- | ----------------------- |        
+            | GET /open-banking/automatic-payments/v2/pix/recurring-payments/{recurringPaymentId}​   | Pix - Consultar iniciação de pagamento​                                                                                       | -                                    | -
+            | --------- | ----------------- | ----------------------- | ----------------------- |
+            | PATCH /open-banking/automatic-payments/v2/pix/recurring-payments/{recurringPaymentId}​ | Pix - Cancelar iniciação de pagamento​​                                                                                        | Será necessário o reporte porém temos que aguardar a <br> definição do nome do campo pelo GT Especificações Serviços​                      | -
+            <br>
+
+          type: string
+          enum:
+            - INICIADORA
+            - DETENTORA
+        amountType:
+          description: |
+            Valida se o serviço contratado possui maior conversão em relação ao tipo do valor definido, sendo ele fixo ou variável​.
+          type: string
+          enum:
+            - FIXO
+            - VARIAVEL
+        interval:
+          description: |
+            Periodicidade que a recorrência foi definida (semanal, trimestral, anual...)​.
+            
+            Regras:
+              - Preencher com o valor do campo "interval"​
+          type: string
+        isFirstPayment:
+          description: |
+            Valida se o serviço possui um pagamento associado na adesão.
+          type: string
+          enum:
+            - "TRUE"
+            - "FALSE"
+        hasMinimumAmount:
+          description: |
+            Valida se possui o valor mínimo definido pelo usuário recebedor​.
+          type: string
+          enum:
+            - "TRUE"
+            - "FALSE"
+        isRetryAccepted:
+          description: |
+            Identifica se foi autorizado a tentativas de pagamento em dias subsequentes na situação de falha do pagamento da recorrência
+            
+            Regras:
+              - Preencher com o valor do campo "isRetryAccepted"​
+          type: string
+        recurringPaymentId:
+          description: |
+            Contagem de acionamentos feitos no pagamento
+            
+            Regras:
+              - Para Pagamentos v4: Preencher com o valor do campo "/data/paymentId"
+              - Para Pagamentos Automáticos v2: Preencher com o valor do campo "/data/recurringPaymentId"​
+          type: string
+        originalRecurringPaymentId:
+          description: |
+            Identifica o primeiro pagamento da recorrência em relação as retentativas​.
+            
+            Regras:
+              - Preencher com o valor do campo "originalRecurringPaymentId"​
+          type: string
+        paymentReference:
+          description: |
+            Identifica a referência do pagamento no tempo (semanal, mensal, trimestral...).
+            
+            Regras:​
+              - Preencher com o valor do campo "paymentReference"
+          type: string
+        cancellationReason: 
+          description: |
+            Identifica o estado que o pagamento estava quando foi cancelado​.
+            
+            Regras:
+              - Preencher com o valor do campo "cancellation.reason"
+          type: string
+        nfcPayment:
+          description: |
+            Indica se o pagamento foi realizado via NFC.
+            
+            Regras:
+              - Preencher com o valor do campo "nfcPayment"
+          type: string
+          enum:
+            - "TRUE"
+            - "FALSE"
+        
+    OpendataAdditionalInfo:
+      description: Informações adicionais sobre o reporte deste endpoint/método. Possui característica variável. As regras de preenchimento estão na documentação funcional em [https://openfinancebrasil.atlassian.net/wiki/spaces/OF/pages/37879861/Reporte#additionalInfo](https://openfinancebrasil.atlassian.net/wiki/spaces/OF/pages/37879861/Reporte#additionalInfo). Atenção especial na tabela Excel com a listagem de endpoints em [https://openfinancebrasil.atlassian.net/wiki/spaces/OF/pages/806158355/Planilha+AdditionalInfo](https://openfinancebrasil.atlassian.net/wiki/spaces/OF/pages/806158355/Planilha+AdditionalInfo).
+      type: object
+      properties: 
+        paymentType:
+          description: |
+            Identifica o modo de pagamento acionado no consentimento
+            1. Envio obrigatório para a role Client​ 
+            2. Conteudo ENUM do novo campo varia de acordo com o endpoint conforme tabela abaixo
+            
+            | Endpoint | Valores possíveis |
+            |----------|-------------|
+            | <br>POST /open-banking/payments/v4/consents&nbsp;&nbsp;&nbsp;    |  <br>IMMEDIATE<br>SCHEDULED<br>RECURRENT
+            |----------|-------------|
+            | <br>POST /open-banking/payments/v4/pix/payments&nbsp;&nbsp;&nbsp;    |  <br>IMMEDIATE<br>SCHEDULED<br>RECURRENT<br>AUTOMATIC
+            |----------|-------------|
+            | <br>PATCH /open-banking/payments/v4/pix/payments/{paymentId}​&nbsp;&nbsp;&nbsp;    |  <br>IMMEDIATE<br>SCHEDULED<br>RECURRENT<br>AUTOMATIC
+            |----------|-------------|
+            | <br>POST /automatic-payments/v1/recurring-consents&nbsp;&nbsp;&nbsp;    |  <br>SWEEPING
+            |----------|-------------|
+            | <br>PATCH /automatic-payments/v1/recurring-consents/{consentId}&nbsp;&nbsp;&nbsp;    |  <br>SWEEPING
+            |----------|-------------|
+            | <br>POST /automatic-payments/v1/pix/recurring-payments&nbsp;&nbsp;&nbsp;    |  <br>SWEEPING<br>AUTOMATIC
+            |----------|-------------|
+            | <br>PATCH /automatic-payments/v1/pix/recurring-payments/{paymentId}&nbsp;&nbsp;&nbsp;   |  <br>SWEEPING<br>AUTOMATIC
+            <br>
+          type: string
+        amountType:
+          description: |
+            Valida se o serviço contratado possui maior conversão em relação ao tipo do valor definido, sendo ele fixo ou variável​.
+          type: string
+          enum:
+            - FIXO
+            - VARIAVEL
+        interval:
+          description: |
+            Periodicidade que a recorrência foi definida (semanal, trimestral, anual...)​.
+            
+            Regras:
+              - Preencher com o valor do campo "interval"​
+          type: string
+        isFirstPayment:
+          description: |
+            Valida se o serviço possui um pagamento associado na adesão.
+          type: string
+          enum:
+            - "TRUE"
+            - "FALSE"
+        hasMinimumAmount:
+          description: |
+            Valida se possui o valor mínimo definido pelo usuário recebedor​.
+          type: string
+        isRetryAccepted:
+          description: |
+            Identifica se foi autorizado a tentativas de pagamento em dias subsequentes na situação de falha do pagamento da recorrência
+            
+            Regras:
+              - Preencher com o valor do campo "isRetryAccepted"​
+          type: string
+        recurringPaymentId:
+          description: |
+            Contagem de acionamentos feitos no pagamentos
+
+            Regras:
+              - Para Pagamentos v4: Preencher com o valor do campo "/data/paymentId"
+              - Para Pagamentos Automáticos v2: Preencher com o valor do campo "/data/recurringPaymentId"​
+          type: string
+        originalRecurringPaymentId:
+          description: |
+            Identifica o primeiro pagamento da recorrência em relação as retentativas​.
+            
+            Regras:
+              - Preencher com o valor do campo "originalRecurringPaymentId"​
+          type: string
+        paymentReference:
+          description: |
+            Identifica a referência do pagamento no tempo (semanal, mensal, trimestral...).
+            
+            Regras:​
+              - Preencher com o valor do campo "paymentReference"
+          type: string
+        cancellationReason: 
+          description: |
+            Identifica o estado que o pagamento estava quando foi cancelado​.
+            
+            Regras:
+              - Preencher com o valor do campo "cancellation.reason"
+          type: string
+
+    GenericError:
+      description: Representa uma resposta de erro genérica.
+      type: object
+      additionalProperties: false
+      properties:
+        message:
+          type: string
+          pattern: ^[- /:_.',0-9a-zA-Z]{0,200}$
+          maxLength: 200
+
+    EmptyObject:
+      description: Representa um objeto sem propriedades previamente definidas
+      type: object
+      additionalProperties: false
+      example: {}
+
+    ConsentStockRequest:
+      description: ""
+      type: object
+      required:
+        - "date"
+        - "orgId"          
+        - "role"
+        - "scope"
+        - "totalAmountOfUniqueClients"
+        - "clientOrgId"
+        - "serverOrgId"
+        - "consentsStockList"
+      properties:
+        date:
+          description: Data UTC no formato ISO8601 (YYYY-MM-DD) do momento em que a chamada foi disparada, imediatamente antes do primeiro byte enviado na requisição. Deve conter a data a que se referem os dados de consentimento enviados na mensagem.
+          type: string
+          format: date
+          maxLength: 10
+          example: "2021-11-11"
+        orgId: 
+          description: Organização de envio da mensagem referente ao papel do Transmissor ou Receptor, conforme Role, a ser preenchido a partir do Certificado. 
+          type: string
+          format: uuid
+          maxLength: 36
+          pattern: "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+          example: "c1ca8e62-9d6f-4ea3-84f2-d66bc0a8f7dc"
+        role:
+          description: ENUM indicando se o reporte que está sendo enviado apresenta a visão do SERVER ou do CLIENT.
+          type: string
+          enum:
+            - CLIENT
+            - SERVER
+        scope:
+          description: "A ser preenchido com a role 'Dados'"
+          type: string
+          enum:
+            - DADOS
+        totalCustomerPF:
+          description: "A ser preenchido com o total de clientes PF com consentimentos ativos. Formato: Númerico inteiro natural"
+          type: number
+        totalCustomerPJ:
+          description: "A ser preenchido com o total de clientes PJ com consentimentos ativos. Formato: Númerico inteiro natural"
+          type: number
+        consentsStockList:
+          type: array
+          minItems: 1
+          items:
+            type: object
+            properties:
+              clientOrgId:
+                description: Identificador da organização de onde a chamada foi disparada.
+                allOf:
+                  - $ref: "#/components/schemas/UUID"
+              serverOrgId:
+                description: Identificador da organização para onde a chamada foi feita.
+                type: string
+                format: uuid
+                maxLength: 36
+                pattern: "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+                example: "c1ca8e62-9d6f-4ea3-84f2-d66bc0a8f7dc"
+              totalActiveConsents: 
+                description: Estoque total de consentimentos ativos, correspondendo ao número de consentimentos totais válidos até a data de referência.
+                type: number
+
+    ConsentStockResponse:
+      description: Representa os dados que serão retornados pelas operações de inclusão de consentiments.
+      additionalProperties: false
+      required:
+        - reportId
+        - status
+      type: object
+      properties:
+        reportId:
+          description: Identificador único interno do reporte no formato UUID v4.
+          type: string
+          format: uuid
+          maxLength: 36
+          pattern: "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+          example: "9a97c2df-b261-4fc2-aa66-d1b5168397da"
+        status:
+          $ref: "#/components/schemas/ReportStatus"
+        message:
+          description: Caso a solicitação contenha algum problema em seu formato, ou caso haja algum tipo de falha detectável no momento da requisição, esse campo trará detalhes sobre o erro ocorrido. Informações adicionais sobre os tipos de erros podem ser encontradas em [https://openfinancebrasil.atlassian.net/wiki/spaces/OF/pages/46170119/Troubleshooting+-+PCM](https://openfinancebrasil.atlassian.net/wiki/spaces/OF/pages/46170119/Troubleshooting+-+PCM)
+          type: string
+          pattern: ^[- /:_.',0-9a-zA-Z]{0,200}$
+          maxLength: 200
+          example: "Missing fields: 'fapiInteractionId', 'endpoint'"
+
+    CreditPortabilityClientRequest:
+      description: "A Portabilidade de Crédito permite que os usuários transfiram suas operações de crédito e arrendamento mercantil entre instituições financeiras em busca de melhores condições."
+      type: array
+      minItems: 1
+      maxItems: 5000
+      items:
+        type: object
+        required:
+          - "portabilityId"          
+          - "contractId"
+          - "creationDateTime"
+          - "productSubTypeCategory"
+          - "originalContractCET"
+          - "originalPropositionCET"
+          - "originalContractTerm"
+          - "propositionTerm"
+          - "creditPortabilityStatus"
+          - "rejectionReason"
+          - "timestamp"
+          - "fapiInteractionId"
+          - "endpoint"
+          - "endpointUriPrefix"
+          - "httpMethod"
+          - "statusCode"
+          - "reportId"
+          - "clientOrgId"
+          - "serverOrgId"
+          - "clientSSId"
+          - "role"
+        properties:
+          timestamp:
+            description: |
+              Data/Hora UTC no formato ISO8601 com milissegundos (YYYY-MM-DDTHH:mm:ss.sssZ) do momento em que a chamada foi disparada, imediatamente antes do primeiro byte enviado na requisição.
+            type: string
+            maxLength: 28
+            example: "2021-11-11T18:08:08.278Z"
+          portabilityId: 
+            description: Código identificador do pedido de portabilidade realizado.
+            type: string
+            format: uuid
+            maxLength: 100
+            minLength: 1
+            pattern: "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+            example: "54d5348c-1a3f-4ff4-a8a8-d0724fb806c6"
+          contractId:
+            description: Identifica de forma única o contrato da operação de crédito do cliente, mantendo as regras de imutabilidade dentro da instituição transmissora.
+            type: string
+            minLength: 1
+            maxLength: 100
+            pattern: ^[a-zA-Z0-9][a-zA-Z0-9-]{0,99}$
+            example: "92792126019929279212650822221989319252576"
+          creationDateTime:
+            description: "Data e hora em que a Proponente registrou a presente proposta (chamada ao POST /portabilities). Uma string com data e hora conforme especificação ISO8601, sempre com a utilização de timezone UTC-0 (UTC time format)."
+            type: string
+            minLength: 20
+            maxLength: 20
+            pattern: ^(\d{4})-(1[0-2]|0?[1-9])-(3[01]|[12][0-9]|0?[1-9])T(?:[01]\d|2[0123]):(?:[012345]\d):(?:[012345]\d)Z$
+            example: "2020-07-21T08:30:00Z"
+          productSubTypeCategory:
+            description: "Categoria para classificação específica relacionada com a submodalidade do produto"
+            type: string
+            example: "CREDITO_PESSOAL_CLEAN"
+          originalContractCET:
+            description: |
+              •	CET – Custo Efetivo Total deve ser expresso na forma de taxa percentual anual e incorpora todos os encargos e despesas incidentes nas operações de crédito (taxa de juro, mas também tarifas, tributos, seguros e outras despesas cobradas). 
+              O preenchimento deve respeitar as 6 casas decimais, mesmo que venham preenchidas com zeros (representação de porcentagem p.ex: 0.150000. 
+              Este valor representa 15%. O valor 1 representa 100%). 
+              Para o público PF (pessoa física) o campo é de envio obrigatório para contratos firmados a partir de 2008, conforme Resolução CMN 3.517. 
+              Para o público PJ (pessoa jurídica) o campo é de envio obrigatório para contratos firmados a partir de 2011, conforme Resolução CMN 3.909. 
+              O campo poderá ser preenchido com 0.00 em cenários nos quais a casa não tenha a informação de CET (Custo efetivo total) apenas para as exceções listadas abaixo:
+
+              - Em contratos anteriores a 2008 (para o público PF) 
+              - Em contratos anteriores a 2011 (para o público PJ);
+              - Público PJ de médio ou grande porte.
+            type: string
+            minLength: 8
+            maxLength: 13
+            pattern: ^\d{1,6}\.\d{6}$
+            example: "0.290000"
+          originalPropositionCET:
+            description: |
+              •	CET – Custo Efetivo Total deve ser expresso na forma de taxa percentual anual e incorpora todos os encargos e despesas incidentes nas operações de crédito (taxa de juro, mas também tarifas, tributos, seguros e outras despesas cobradas). 
+              O preenchimento deve respeitar as 6 casas decimais, mesmo que venham preenchidas com zeros (representação de porcentagem p.ex: 0.150000. 
+              Este valor representa 15%. O valor 1 representa 100%). 
+              Para o público PF (pessoa física) o campo é de envio obrigatório para contratos firmados a partir de 2008, conforme Resolução CMN 3.517. 
+              Para o público PJ (pessoa jurídica) o campo é de envio obrigatório para contratos firmados a partir de 2011, conforme Resolução CMN 3.909. 
+              O campo poderá ser preenchido com 0.00 em cenários nos quais a casa não tenha a informação de CET (Custo efetivo total) apenas para as exceções listadas abaixo:
+
+              - Em contratos anteriores a 2008 (para o público PF) 
+              - Em contratos anteriores a 2011 (para o público PJ);
+              - Público PJ de médio ou grande porte.
+            type: string
+            minLength: 8
+            maxLength: 13
+            pattern: ^\d{1,6}\.\d{6}$
+            example: 0.290000
+          originalContractTerm:
+            description: Prazo restante do contrato original de empréstimo.
+            type: number
+            maximum: 999999
+            example: 57
+          propositionTerm:
+            description: "Prazo da proposta de portabilidade de crédito"
+            type: number
+            maximum: 999999999
+            example: 30
+          creditPortabilityStatus: 
+            description: |
+              Informação sobre o status de um pedido de portabilidade de crédito, onde:
+              - `RECEIVED`: Estado inicial. Indica que o pedido de portabilidade foi solicitado junto à instituição credora. O pedido deve permanecer neste estado até o próximo dia útil (D+1) onde começará a contar o prazo de 3 dias úteis para a etapa de contraproposta e o pedido de portabilidade deverá ser movido para PENDING 
+              - `PENDING`: Indica que o pedido de portabilidade de crédito está na fase de contraproposta, onde a instituição credora poderá enviar uma contraproposta ou não para o cliente por qualquer canal (email, telefone, etc.) porém o aceite só deverá ser valido se o cliente aprovar no canal digital da instituição credora
+              - `ACCEPTED_SETTLEMENT_IN_PROCESS`: Indica que a contraproposta não foi aceita pelo cliente e a instituição proponente terá que quitar o valor do contrato no mesmo dia em que o estado foi ativado.
+              - `ACCEPTED_SETTLEMENT_COMPLETED`: Indica que a instituição proponente já liquidou o contrato e comunicou a respeito à credora que está validando os dados do contrato bem como valores recebidos para a quitação do mesmo (nesta etapa a instituição credora tem 2 dias úteis para fornecer a confirmação e o recibo de quitação do contrato de empréstimo)
+              - `PORTABILITY_COMPLETED`: Indica que o pedido de portabilidade foi concluído com sucesso REJECTED: Indica que o pedido de portabilidade de crédito foi rejeitado, seja porque o cliente aceitou a contraproposta, ou porque a proponente rejeitou a liquidação que excedeu em 15% o valor do contrato original, entre outras possibilidades
+              - `CANCELLED`: Indica que o cliente cancelou o pedido de portabilidade de crédito 
+              - `PAYMENT_ISSUE`: Indica que a Instituição Credora encontrou alguma inconsistência na liquidação efetuada e que a Instituição Proponente deverá realizar ajustes conforme sugerido pela Instituição Credora para solucionar a pendência antes do cancelamento do pedido de portabilidade de crédito
+              - `REJECTED`: Indica que o pedido de portabilidade de crédito foi rejeitado, seja porque o cliente aceitou a contraproposta, ou porque a proponente rejeitou a liquidação que excedeu em 15% o valor do contrato original, entre outras possibilidades
+            type: string
+            enum:
+              - PENDING 
+              - RECEIVED 
+              - ACCEPTED_SETTLEMENT_IN_PROCESS
+              - ACCEPTED_SETTLEMENT_COMPLETED
+              - PORTABILITY_COMPLETED
+              - REJECTED
+              - CANCELLED
+              - PAYMENT_ISSUE
+          statusUpdateDateTime:
+            description: "•	Data e hora em que o contrato teve o status atualizado. Uma string com data e hora conforme especificação ISO-8601, sempre com a utilização de timezone UTC(UTC time format)."
+            type: string
+            maxLength: 20
+            pattern: ^(\d{4})-(1[0-2]|0?[1-9])-(3[01]|[12][0-9]|0?[1-9])T(?:[01]\d|2[0123]):(?:[012345]\d):(?:[012345]\d)Z$
+            example: "2020-07-21T08:30:00Z"
+          rejectionReason:
+            description: |
+              Motivo de recusa do pedido de portabilidade.
+                - Só será preenchido caso o status seja `REJECTED`, `CANCELLED` ou `PAYMENT_ISSUE`
+                - A consulta ao endpoint de GET é requerida para o fluxo de portabilidade
+            type: string
+            enum:
+              - CANCELADO_PELO_CLIENTE
+              - SALDO_DEVEDOR_ATUALIZADO_SUBSTANCIALMENTE_DIVERGENTE
+              - POLITICA_DE_CREDITO
+              - RETENCAO_DO_CLIENTE
+              - CONTRATO_JA_LIQUIDADO
+              - DIVERGENCIA_DE_PAGAMENTO_EFETUADO
+              - DECURSO_DO_PRAZO_PARA_PAGAMENTO
+              - PORTABILIDADE_CANCELADA_POR_FALTA_DE_LIQUIDACAO
+              - PORTABILIDADE_EM_ANDAMENTO
+              - CLIENTE_COM_ACAO_JUDICIAL
+              - MODALIDADE_DA_OPERACAO_INCOMPATIVEL
+              - OUTROS
+          rejectedBy:
+            description: |
+              Informar usuário responsável pela rejeição da proposta, onde: PROPONENTE - Indica que o pedido de portabilidade de crédito foi rejeitado pela proponente, seja porque a proponente rejeitou a liquidação que excedeu em 15% o valor do contrato original, entre outras possibilidades. USUARIO - Indica que o cliente cancelou o pedido de portabilidade de crédito. CREDORA- Indica que a Instituição Credora cancelou o contrato por retenção do cliente ou outros motivos conforme motivo de recusa.
+
+                - Só será preenchido caso o status seja REJECTED ou CANCELLED
+            type: string
+            enum:
+              - PROPONENTE
+              - USUARIO
+              - CREDORA
+          fapiInteractionId:
+            description: |
+              UUID que identifica uma transação específica entre dois participantes. Esse dado pode ser encontrado no header x-fapi-interaction-id informado pelo Client e devolvido pelo Server. Mais informações em Cabeçalhos HTTP na documentação do Open Finance Brasil. O envio dessa informação é obrigatório, exceto nos casos ontem ela não esteja disponível como, por exemplo, em respostas com status 5xx, ou em chamadas que terminaram por timeout onde o reporte tem que ser enviado, mas sem esse atributo. Nos demais cenários, o envio é obrigatório.
+            type: string
+            format: uuid
+            maxLength: 36
+            pattern: "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+            example: "d78fc4e5-37ca-4da3-adf2-9b082bf92280"
+          endpoint: 
+            description: |
+              Identificação do endpoint que foi utilizado na transação reportada. A identificação do endpoint deve estar entre as entradas desse enum para ser considerado válido. Nesse campo não deve ser utilizado o path da requisição original, uma vez que ao comparar com os valores dessa enum, ele não será considerado válido.
+            type: string
+            example: "/open-banking/consents/v2/consents"
+          endpointUriPrefix:
+            description: |
+              Endereço do servidor de destino da chamada, incluindo o prefixo quando houver. 
+              O formato do campo deverá ser o seguinte: `https://{host}/{prefixo}`, sendo:
+
+              - host: endereço FQDN do servidor de destino
+              - prefixo: toda a parte do path que vem antes da string /open-banking
+            type: string
+            pattern: ^[- /:_.',0-9a-zA-Z]{0,200}$
+            maxLength: 200
+            example: https://openbanking.instituicao-1.com.br/opbk
+          httpMethod: 
+            description: Método HTTP da solicitação.
+            type: string
+            enum: ["GET", "POST", "PUT", "DELETE", "PATCH"]
+            example: POST
+          correlationId:
+            description: |
+              ID de correlação que identifica uma sequência de chamadas inter-relacionadas no ecossistema. Diferente do fapiInteractionId que serve para identificar cada par request-response (interação), o identificador de correlação serve para ligar diferentes reportes quando estes representam uma jornada ou uma sequência de chamadas. Este valor é de livre provimento pelo reportador.
+            type: string
+            pattern: ^[- /:_.',0-9a-zA-Z]{0,100}$
+            maxLength: 100
+            example: uGQHwNupARo7I9E2PLJZph18a0M9y7DcUe7ITt3DqUOJd9NVjnskxf2
+          statusCode:
+            description: Status de retorno HTTP da solicitação. No caso de ocorrer um timeout client side preencher com um código 403 (conforme documentação ).
+            type: integer
+            format: int32
+            example: 200
+            minimum: 200
+            maximum: 599
+          reportId:
+            description: Identificador único interno do reporte no formato UUID v4.
+            type: string
+            format: uuid
+            maxLength: 36
+            pattern: "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+            example: "9a97c2df-b261-4fc2-aa66-d1b5168397da"
+          processTimespan:
+            description: "Tempo em milissegundos inteiros decorrido desde o registro do timestamp até a chegada do primeiro byte da resposta do server."
+            type: integer
+            example: 120
+          clientOrgId:
+            description: Identificador da organização de onde a chamada foi disparada.
+            allOf:
+              - $ref: "#/components/schemas/UUID"
+          serverOrgId:
+            description: Identificador da organização para onde a chamada foi feita.
+            type: string
+            format: uuid
+            maxLength: 36
+            pattern: "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+            example: "c1ca8e62-9d6f-4ea3-84f2-d66bc0a8f7dc"
+          clientSSId:
+            description: |
+              Identificador do software statement de onde a chamada foi disparada. A PCM garante que foi esta orgId que obteve o token de acesso utilizado neste reporte.
+            type: string
+            maxLength: 36
+            pattern: ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$
+            example: "84570da9-567b-4201-9b77-c715bc5bffde"
+          role:
+            description: ENUM indicando se o reporte que está sendo enviado apresenta a visão do server ou do client.
+            type: string
+            enum:
+              - CLIENT
+              - SERVER
+
+    CreditPortabiltyServerRequest:
+      description: Representa os dados que deverão ser enviados para a inclusão de reportes pelo lado do Server (receptor da chamada). Informações adicionais sobre cada campo podem ser encontradas na documentação funcional em [https://openfinancebrasil.atlassian.net/wiki/spaces/OF/pages/37879861/Reporte#Modelos-para-reportes-Private](https://openfinancebrasil.atlassian.net/wiki/spaces/OF/pages/37879861/Reporte#Modelos-para-reportes-Private)
+      type: array
+      minItems: 1
+      maxItems: 5000
+      items: 
+        type: object 
+        required:
+          - fapiInteractionId
+          - endpoint
+          - statusCode
+          - httpMethod
+          - timestamp
+          - processTimespan
+          - clientOrgId
+          - serverOrgId
+          - role
+        properties:
+          fapiInteractionId:
+            description: UUID que identifica uma transação específica entre dois participantes. Esse dado pode ser encontrado no header x-fapi-interaction-id que é informado pelo Client e devolvido pelo Server. Mais informações em [Cabeçalhos HTTP](https://openbanking-brasil.github.io/areadesenvolvedor/#cabecalhos-http) na documentação do Open Finance Brasil.
+            type: string
+            format: uuid
+            maxLength: 36
+            pattern: "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+            example: "d78fc4e5-37ca-4da3-adf2-9b082bf92280"
+          endpoint:
+            $ref: "#/components/schemas/PrivateReportEndpoints"
+          statusCode:
+            description: Status de retorno HTTP da solicitação. No caso de ocorrer um timeout client side preencher com um código 408 [conforme documentação](https://openfinancebrasil.atlassian.net/wiki/spaces/OF/pages/37879861/Reporte)
+            type: integer
+            format: int32
+            example: 200
+            minimum: 200
+            maximum: 599
+          httpMethod:
+            description: Método HTTP da solicitação.
+            type: string
+            enum: ["GET", "POST", "PUT", "DELETE", "PATCH"]
+            example: GET
+          correlationId:
+            description: Não utilizado pelo server.
+            type: string
+            pattern: ^[- /:_.',0-9a-zA-Z]{0,100}$
+            maxLength: 100
+            example: "uGQHwNupARo7I9E2PLJZph18a0M9y7DcUe7ITt3DqUOJd9NVjnskxf2"
+          timestamp:
+            description: Data/Hora UTC no formato ISO8601 com milissegundos (YYYY-MM-DDTHH:mm:ss.sssZ) do momento em que a chamada foi recebida, imediatamente antes do primeiro byte enviado na requisição.
+            type: string
+            format: date-time
+            maxLength: 28
+            example: "2021-11-11T18:08:08.152Z"
+          processTimespan:
+            description: Tempo em milissegundos inteiros decorrido desde o registro do timestamp até a finalização do envio dos dados.
+            type: integer
+            format: int16
+            example: 120
+          clientOrgId:
+            description: Identificador da organização **de onde** a chamada foi disparada.
+            allOf:
+              - $ref: "#/components/schemas/UUID"
+          serverOrgId:
+            allOf:
+              - $ref: "#/components/schemas/UUID"
+            description: Identificador da organização **para onde** a chamada foi feita. A PCM garante que foi esta orgId que obteve o token de acesso utilizado neste reporte.
+          statusUpdateDateTime:
+            description: "•	Data e hora em que o contrato teve o status atualizado. Uma string com data e hora conforme especificação ISO-8601, sempre com a utilização de timezone UTC(UTC time format)."
+            type: string
+            maxLength: 20
+            pattern: ^(\d{4})-(1[0-2]|0?[1-9])-(3[01]|[12][0-9]|0?[1-9])T(?:[01]\d|2[0123]):(?:[012345]\d):(?:[012345]\d)Z$
+            example: "2020-07-21T08:30:00Z"
+          rejectionReason:
+            description: |
+              Motivo de recusa do pedido de portabilidade.
+                - Só será preenchido caso o status seja `REJECTED`, `CANCELLED` ou `PAYMENT_ISSUE`
+                - A consulta ao endpoint de GET é requerida para o fluxo de portabilidade
+            type: string
+            enum:
+              - CANCELADO_PELO_CLIENTE
+              - SALDO_DEVEDOR_ATUALIZADO_SUBSTANCIALMENTE_DIVERGENTE
+              - POLITICA_DE_CREDITO
+              - RETENCAO_DO_CLIENTE
+              - CONTRATO_JA_LIQUIDADO
+              - DIVERGENCIA_DE_PAGAMENTO_EFETUADO
+              - DECURSO_DO_PRAZO_PARA_PAGAMENTO
+              - PORTABILIDADE_CANCELADA_POR_FALTA_DE_LIQUIDACAO
+              - PORTABILIDADE_EM_ANDAMENTO
+              - CLIENTE_COM_ACAO_JUDICIAL
+              - MODALIDADE_DA_OPERACAO_INCOMPATIVEL
+              - OUTROS
+          rejectedBy:
+            description: |
+              Informar usuário responsável pela rejeição da proposta, onde: PROPONENTE - Indica que o pedido de portabilidade de crédito foi rejeitado pela proponente, seja porque a proponente rejeitou a liquidação que excedeu em 15% o valor do contrato original, entre outras possibilidades. USUARIO - Indica que o cliente cancelou o pedido de portabilidade de crédito. CREDORA- Indica que a Instituição Credora cancelou o contrato por retenção do cliente ou outros motivos conforme motivo de recusa.
+
+                - Só será preenchido caso o status seja REJECTED ou CANCELLED
+            type: string
+            enum:
+              - PROPONENTE
+              - USUARIO
+              - CREDORA
+          role:
+            description: ENUM indicando se o reporte que está sendo enviado apresenta a visão do server ou do client. Obrigatório valor "SERVER"
+            type: string
+            enum:
+              - CLIENT
+              - SERVER
+          creditPortabilityStatus: 
+            description: |
+              Informação sobre o status de um pedido de portabilidade de crédito, onde:
+              - `RECEIVED`: Estado inicial. Indica que o pedido de portabilidade foi solicitado junto à instituição credora. O pedido deve permanecer neste estado até o próximo dia útil (D+1) onde começará a contar o prazo de 3 dias úteis para a etapa de contraproposta e o pedido de portabilidade deverá ser movido para PENDING 
+              - `PENDING`: Indica que o pedido de portabilidade de crédito está na fase de contraproposta, onde a instituição credora poderá enviar uma contraproposta ou não para o cliente por qualquer canal (email, telefone, etc.) porém o aceite só deverá ser valido se o cliente aprovar no canal digital da instituição credora
+              - `ACCEPTED_SETTLEMENT_IN_PROCESS`: Indica que a contraproposta não foi aceita pelo cliente e a instituição proponente terá que quitar o valor do contrato no mesmo dia em que o estado foi ativado.
+              - `ACCEPTED_SETTLEMENT_COMPLETED`: Indica que a instituição proponente já liquidou o contrato e comunicou a respeito à credora que está validando os dados do contrato bem como valores recebidos para a quitação do mesmo (nesta etapa a instituição credora tem 2 dias úteis para fornecer a confirmação e o recibo de quitação do contrato de empréstimo)
+              - `PORTABILITY_COMPLETED`: Indica que o pedido de portabilidade foi concluído com sucesso REJECTED: Indica que o pedido de portabilidade de crédito foi rejeitado, seja porque o cliente aceitou a contraproposta, ou porque a proponente rejeitou a liquidação que excedeu em 15% o valor do contrato original, entre outras possibilidades
+              - `CANCELLED`: Indica que o cliente cancelou o pedido de portabilidade de crédito 
+              - `PAYMENT_ISSUE`: Indica que a Instituição Credora encontrou alguma inconsistência na liquidação efetuada e que a Instituição Proponente deverá realizar ajustes conforme sugerido pela Instituição Credora para solucionar a pendência antes do cancelamento do pedido de portabilidade de crédito
+              - `REJECTED`: Indica que o pedido de portabilidade de crédito foi rejeitado, seja porque o cliente aceitou a contraproposta, ou porque a proponente rejeitou a liquidação que excedeu em 15% o valor do contrato original, entre outras possibilidades
+            type: string
+            enum:
+              - PENDING 
+              - RECEIVED 
+              - ACCEPTED_SETTLEMENT_IN_PROCESS
+              - ACCEPTED_SETTLEMENT_COMPLETED
+              - PORTABILITY_COMPLETED
+              - REJECTED
+              - CANCELLED
+              - PAYMENT_ISSUE
+
+    CreditPortabilityReportModel:
+      description: Representa um reporte devidamente persistido.
+      allOf:
+        - $ref: "#/components/schemas/CreditPortabilityClientRequest"
+        - type: object
+          properties:
+            reportId:
+              description: |
+                Identificador único do registro criado na Plataforma de Coleta de Métricas.
+              type: string
+              format: uuid
+              maxLength: 36
+              pattern: "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+            pairedReportId:
+              description: |
+                Esse atributo indica o `reportId` do registro que forma uma correlação com o presente registro. Se essa informação existir, o status do registro atual deverá ser _PAIRED_
+              type: string
+              format: uuid
+              maxLength: 36
+              pattern: "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+            creditPortabilityStatus:
+              $ref: "#/components/schemas/CreditPortabilityStatus"
+            createdAt:
+              description: |
+                Carimbo do tempo do momento da criação do registro
+              type: string
+              format: date-time
+              maxLength: 28
+            updatedAt:
+              description: |
+                Carimbo do tempo do momento da última atualização do registro
+              type: string
+              format: date-time
+              maxLength: 28
+
+    UUID:
+      type: string
+      format: uuid
+      maxLength: 36
+      pattern: "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+      example: "d78fc4e5-37ca-4da3-adf2-9b082bf92280"
+
+  securitySchemes:
+    PCMAccessToken:
+      description: Token de acesso JWT para autenticação nas APIs da PCM.
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+  responses:
+    Default401Unauthorized:
+      description: Ocorre quando uma requisição não é autorizada pelo gateway, e acontece quando o token não é enviado ou está inválido.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/GenericError"
+          examples:
+            NotAuthorized:
+              value:
+                message: "Unauthorized"
+    Default403Forbidden:
+      description: Ocorre quando um cliente já previamente identificado (autenticado) não é autorizado a acessar um determinado recurso.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/GenericError"
+          examples:
+            Forbidden:
+              value:
+                message: "Forbidden"
+    Default404NotFound:
+      description: Ocorre quando o reporte referenciado nao existe na base de dados.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/GenericError"
+          examples:
+            Forbidden:
+              value:
+                message: "Not Found"
+    Default406NotAcceptable:
+      description: Ocorre quando um cliente espera uma resposta diferente de application/json usando o header `Accept`
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/GenericError"
+          examples:
+            NotAcceptable:
+              value:
+                message: "Content type not accepted"
+    Default415UnsupportedMediaType:
+      description: Ocorre quando uma requisição envia um Content Type diferente de application/json
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/GenericError"
+          examples:
+            NotAcceptable:
+              value:
+                message: "Unsupported Media Type"
+    Default429TooManyRequests:
+      description: Ocorre quando o servidor atinge o limite de requisições (atualmente, 300 req/s).
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/GenericError"
+          examples:
+            NotAcceptable:
+              value:
+                message: "Too Many Requests"
+    Default500InternalServerError:
+      description: É devolvido quando ocorre um erro não identificado no servidor
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/GenericError"
+          examples:
+            InternalServerError:
+              value:
+                message: "Internal Server Error"
+
+  

--- a/swagger-apis/metrics-collection-platform/2.1.2.yml
+++ b/swagger-apis/metrics-collection-platform/2.1.2.yml
@@ -33,7 +33,7 @@ info:
 
     Para informações detalhadas sobre a PCM, consulte o [site da documentação da Plataforma](https://openfinancebrasil.atlassian.net/wiki/spaces/OF/pages/17378055/Plataforma+de+Coleta+de+M+tricas).
 
-  version: 2.1.1
+  version: 2.1.2
   contact:
     name: Governança Open Finance Brasil
   license:
@@ -2115,6 +2115,26 @@ components:
                 enum:
                   - "TRUE"
                   - "FALSE"
+              statusSummary:
+                description: |
+                  Sumarização das quantidades de reportes por status
+
+                  Regras:
+                    - Preencher com o valor do campo "status"
+                type: object
+                properties:
+                  available:
+                    description: disponível
+                    type: number
+                  unavailable:
+                    description: indisponível
+                    type: number
+                  temporarilyUnavailable:
+                    description: temporariamente indisponível
+                    type: number
+                  pendingAuthorisation:
+                    description: pendente de autorização
+                    type: number
               
           timestamp:
             description: Data/Hora UTC no formato ISO8601 com milissegundos (YYYY-MM-DDTHH:mm:ss.sssZ) do momento em que a chamada foi disparada, imediatamente antes do primeiro byte enviado na requisição.


### PR DESCRIPTION
Atualizar especificação (OpenAPI/ Swagger) da PCM para incluir orientações sobre o reporte de additionalInfo

▪Para segregar o monitoramento da jornada do consentimento para o público PJ, o GT Engajamento PJ solicitou que o GT Arquitetura e a DTO definissem o melhor modelo de reportes para a PCM que possibilitasse a observabilidade de recursos e suas evoluções em jornada de múltipla alçada

▪Criação de additionalInfo na PCM que possibilite o reporte pelos receptores de todos os estados observados na API Resources, seguido da quantidade observada naquele GET

O reporte do additionalInfo será de obrigatoriedade do lado CLIENT

O envio deve ser feito quando houver o consumo da API Resources
▫Endpoint: /open-banking/resources/v3/resources
▫Método: GET

▫Campo: sumarização da quantidade por ENUM observado em data.status
–Detalhamento do Enum: [AVAILABLE, UNAVAILABLE, TEMPORARILY_UNAVAILABLE, PENDING_AUTHORISATION]

Como responsável pela documentação, preciso atualizar os manuais e guias da PCM para incluir instruções detalhadas sobre o reporte obrigatório do campo additionalInfo pelos clientes, garantindo clareza sobre o formato, obrigatoriedade e exemplos de uso.