### PR TITLE
TLM1195 - [PCM] Correção swagger addinfo paymentType

### DIFF
--- a/swagger-apis/metrics-collection-platform/2.1.2.yml
+++ b/swagger-apis/metrics-collection-platform/2.1.2.yml
@@ -1962,11 +1962,13 @@ components:
                   - SCHEDULED
                   - RECURRENT​
                   - SWEEPING
+                  - AUTOMATIC
                 x-enum-descriptions:
                   - Pix sem configuração de agendamento​
                   - Pix com configuração de agendamento​
                   - Pix sem configuração de agendamento e configuração de recorrência​
                   - para todas as chamadas de pagamentos inteligentes​
+                  - Pagamentos automaticos
               dropReason:
                 description: |
                   Regras:
@@ -2970,11 +2972,13 @@ components:
             - SCHEDULED
             - RECURRENT​
             - SWEEPING
+            - AUTOMATIC
           x-enum-descriptions:
             - Pix sem configuração de agendamento​
             - Pix com configuração de agendamento​
             - Pix sem configuração de agendamento e configuração de recorrência​
             - para todas as chamadas de pagamentos inteligentes​
+            - Pagamentos Automaticos
         revocationReasonCode:
           description: |
             Código indicador do motivo da revogação


### PR DESCRIPTION
Identificamos uma inconsistência no swagger da api private em específico no addinfo paymentType onde estamos restringindo os enums permitidos, falta indicar o enum Automatic